### PR TITLE
Add OpenAI OAuth PKCE endpoints and admin UI for one-click token import

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -3,7 +3,7 @@
 处理管理员面板的所有页面和操作
 """
 import logging
-from typing import Optional, List
+from typing import Optional, List, Dict
 from fastapi import APIRouter, Depends, HTTPException, status, Request
 from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
 import json
@@ -14,6 +14,7 @@ from app.database import get_db
 from app.dependencies.auth import require_admin
 from app.services.team import TeamService
 from app.services.redemption import RedemptionService
+from app.services.chatgpt import chatgpt_service
 from app.utils.time_utils import get_now
 
 logger = logging.getLogger(__name__)
@@ -43,6 +44,26 @@ class TeamImportRequest(BaseModel):
     account_id: Optional[str] = Field(None, description="Account ID (单个导入)")
     content: Optional[str] = Field(None, description="批量导入内容")
 
+
+
+
+class OAuthAuthorizeRequest(BaseModel):
+    """生成 OAuth 授权链接请求"""
+    client_id: str = Field(..., description="OAuth Client ID")
+    redirect_uri: str = Field("http://localhost:1455/auth/callback", description="回调地址")
+    scope: str = Field("openid email profile offline_access", description="OAuth scope")
+    audience: Optional[str] = Field(None, description="audience（可选）")
+    codex_cli_simplified_flow: bool = Field(True, description="是否启用 codex 简化流程")
+    id_token_add_organizations: bool = Field(True, description="是否在 id_token 中附带组织信息")
+
+
+class OAuthCallbackParseRequest(BaseModel):
+    """OAuth 回调解析请求"""
+    callback_text: str = Field(..., description="完整回调 URL 或回调文本")
+    code_verifier: Optional[str] = Field(None, description="PKCE code_verifier")
+    expected_state: Optional[str] = Field(None, description="期望的 state 值")
+    client_id: Optional[str] = Field(None, description="兜底 client_id")
+    redirect_uri: str = Field("http://localhost:1455/auth/callback", description="回调地址")
 
 class AddMemberRequest(BaseModel):
     """添加成员请求"""
@@ -336,6 +357,114 @@ async def team_import(
 
 
 
+@router.post("/oauth/openai/authorize")
+async def create_openai_oauth_authorize_url(
+    payload: OAuthAuthorizeRequest,
+    current_user: dict = Depends(require_admin)
+):
+    """生成 OpenAI OAuth 授权链接。"""
+    try:
+        client_id = (payload.client_id or "").strip()
+        if not client_id:
+            return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content={"success": False, "error": "client_id 不能为空"})
+
+        auth_data = chatgpt_service.create_oauth_authorize_url(
+            client_id=client_id,
+            redirect_uri=payload.redirect_uri.strip(),
+            scope=payload.scope.strip() or "openid email profile offline_access",
+            audience=(payload.audience.strip() if payload.audience else None),
+            codex_cli_simplified_flow=payload.codex_cli_simplified_flow,
+            id_token_add_organizations=payload.id_token_add_organizations,
+        )
+
+        return JSONResponse(content={"success": True, "data": {
+            "authorize_url": auth_data["authorize_url"],
+            "code_verifier": auth_data["code_verifier"],
+            "state": auth_data["state"],
+            "client_id": client_id
+        }})
+    except Exception as e:
+        logger.error(f"生成 OAuth 授权链接失败: {e}")
+        return JSONResponse(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, content={"success": False, "error": str(e)})
+
+
+@router.post("/oauth/openai/parse-callback")
+async def parse_openai_oauth_callback(
+    payload: OAuthCallbackParseRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: dict = Depends(require_admin)
+):
+    """解析 OAuth 回调内容并提取 token。"""
+    from urllib.parse import parse_qs, urlparse
+
+    try:
+        text = (payload.callback_text or "").strip()
+        if not text:
+            return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content={"success": False, "error": "回调内容不能为空"})
+
+        parsed = urlparse(text)
+        query = parse_qs(parsed.query)
+        fragment = parse_qs(parsed.fragment)
+
+        merged: Dict[str, str] = {}
+        for source in (query, fragment):
+            for k, v in source.items():
+                if v:
+                    merged[k] = v[0]
+
+        if payload.expected_state and merged.get("state") and merged.get("state") != payload.expected_state:
+            return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content={"success": False, "error": "state 不匹配，请重新生成授权链接"})
+
+        access_token = merged.get("access_token")
+        refresh_token = merged.get("refresh_token")
+        client_id = merged.get("client_id") or payload.client_id
+
+        # 如果回调中只有 code，尝试自动换取 AT/RT
+        code = merged.get("code")
+        if code and not access_token:
+            if not payload.code_verifier:
+                return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content={
+                    "success": False,
+                    "error": "回调中是 code 流程，需要 code_verifier 才能兑换 token"
+                })
+            if not client_id:
+                return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content={
+                    "success": False,
+                    "error": "缺少 client_id，无法兑换 token"
+                })
+
+            exchange = await chatgpt_service.exchange_oauth_code(
+                code=code,
+                client_id=client_id,
+                redirect_uri=payload.redirect_uri.strip(),
+                code_verifier=payload.code_verifier.strip(),
+                db_session=db,
+                identifier=f"oauth_{current_user.get('username', 'admin')}"
+            )
+            if not exchange.get("success"):
+                return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=exchange)
+
+            access_token = exchange.get("access_token")
+            refresh_token = exchange.get("refresh_token")
+
+        if not access_token and not refresh_token:
+            return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content={
+                "success": False,
+                "error": "未在回调内容中解析到 access_token/refresh_token 或可兑换的 code"
+            })
+
+        return JSONResponse(content={
+            "success": True,
+            "data": {
+                "access_token": access_token or "",
+                "refresh_token": refresh_token or "",
+                "client_id": client_id or "",
+                "raw": merged
+            }
+        })
+    except Exception as e:
+        logger.error(f"解析 OAuth 回调失败: {e}")
+        return JSONResponse(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, content={"success": False, "error": str(e)})
 
 
 @router.get("/teams/{team_id}/members/list")

--- a/app/services/chatgpt.py
+++ b/app/services/chatgpt.py
@@ -3,8 +3,12 @@ ChatGPT API 服务
 用于调用 ChatGPT 后端 API,实现 Team 成员管理功能
 """
 import asyncio
+import base64
+import hashlib
 import logging
 import random
+import secrets
+from urllib.parse import urlencode
 from typing import Optional, Dict, Any, List
 from curl_cffi.requests import AsyncSession
 from app.services.settings import settings_service
@@ -468,6 +472,80 @@ class ChatGPTService:
                 "error": f"refresh_token 刷新异常: {e}; primary={result.get('error')}",
                 "error_code": result.get("error_code")
             }
+
+    def create_oauth_authorize_url(
+        self,
+        client_id: str,
+        redirect_uri: str,
+        scope: str = "openid email profile offline_access",
+        audience: Optional[str] = None,
+        codex_cli_simplified_flow: bool = True,
+        id_token_add_organizations: bool = True,
+    ) -> Dict[str, str]:
+        """生成 OpenAI OAuth 授权链接（PKCE）。"""
+        verifier = secrets.token_urlsafe(64)
+        challenge = base64.urlsafe_b64encode(
+            hashlib.sha256(verifier.encode("utf-8")).digest()
+        ).decode("utf-8").rstrip("=")
+        state = secrets.token_urlsafe(24)
+
+        query_dict = {
+            "client_id": client_id,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "prompt": "login",
+            "redirect_uri": redirect_uri,
+            "response_type": "code",
+            "scope": scope,
+            "state": state,
+            "codex_cli_simplified_flow": str(codex_cli_simplified_flow).lower(),
+            "id_token_add_organizations": str(id_token_add_organizations).lower(),
+        }
+        if audience:
+            query_dict["audience"] = audience
+
+        query = urlencode(query_dict)
+        return {
+            "authorize_url": f"https://auth.openai.com/oauth/authorize?{query}",
+            "code_verifier": verifier,
+            "state": state,
+        }
+
+    async def exchange_oauth_code(
+        self,
+        code: str,
+        client_id: str,
+        redirect_uri: str,
+        code_verifier: str,
+        db_session: DBAsyncSession,
+        identifier: str = "oauth_exchange"
+    ) -> Dict[str, Any]:
+        """用 OAuth code 兑换 access_token / refresh_token。"""
+        url = "https://auth.openai.com/oauth/token"
+        payload = {
+            "grant_type": "authorization_code",
+            "client_id": client_id,
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "code_verifier": code_verifier,
+        }
+        headers = {"Content-Type": "application/json"}
+
+        result = await self._make_request("POST", url, headers, payload, db_session, identifier)
+        if not result["success"]:
+            return {
+                "success": False,
+                "error": f"code 换 token 失败: {result.get('error', '未知错误')}"
+            }
+
+        data = result.get("data", {})
+        return {
+            "success": True,
+            "access_token": data.get("access_token"),
+            "refresh_token": data.get("refresh_token"),
+            "id_token": data.get("id_token"),
+            "data": data,
+        }
 
     async def clear_session(self, identifier: Optional[str] = None):
         """清理指定身份的会话，若不提供则清理所有"""

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -172,6 +172,101 @@ function toggleWarrantyDays(checkbox, targetId) {
 
 // === Team 导入逻辑 ===
 
+let oauthDraft = {
+    codeVerifier: '',
+    state: '',
+    clientId: ''
+};
+
+async function generateOAuthAuthorizeLink() {
+    const form = document.getElementById('singleImportForm');
+    if (!form) return;
+
+    const inlineClientId = document.getElementById('oauthClientIdInput').value.trim();
+    const formClientId = form.clientId ? form.clientId.value.trim() : '';
+    const clientId = inlineClientId || formClientId;
+
+    if (!clientId) {
+        showToast('请先填写 Client ID（app_xxx）', 'error');
+        return;
+    }
+
+    try {
+        const result = await apiCall('/admin/oauth/openai/authorize', {
+            method: 'POST',
+            body: JSON.stringify({
+                client_id: clientId,
+                redirect_uri: 'http://localhost:1455/auth/callback'
+            })
+        });
+
+        if (!result.success) {
+            showToast(result.error || '生成授权链接失败', 'error');
+            return;
+        }
+
+        const data = result.data || {};
+        oauthDraft.codeVerifier = data.code_verifier || '';
+        oauthDraft.state = data.state || '';
+        oauthDraft.clientId = data.client_id || clientId;
+
+        document.getElementById('oauthAuthorizeUrlOutput').value = data.authorize_url || '';
+        document.getElementById('oauthClientIdInput').value = oauthDraft.clientId;
+        if (form.clientId) form.clientId.value = oauthDraft.clientId;
+
+        showToast('授权链接已生成，复制后去浏览器登录', 'success');
+    } catch (error) {
+        showToast('生成授权链接失败', 'error');
+    }
+}
+
+function copyOAuthAuthorizeUrl() {
+    const url = document.getElementById('oauthAuthorizeUrlOutput').value.trim();
+    if (!url) {
+        showToast('还没有可复制的授权链接', 'error');
+        return;
+    }
+    copyToClipboard(url);
+}
+
+async function parseOAuthCallbackAndFill() {
+    const callbackText = document.getElementById('oauthCallbackInput').value.trim();
+    const form = document.getElementById('singleImportForm');
+
+    if (!callbackText) {
+        showToast('请先粘贴回调 URL', 'error');
+        return;
+    }
+
+    try {
+        const result = await apiCall('/admin/oauth/openai/parse-callback', {
+            method: 'POST',
+            body: JSON.stringify({
+                callback_text: callbackText,
+                code_verifier: oauthDraft.codeVerifier || null,
+                expected_state: oauthDraft.state || null,
+                client_id: (document.getElementById('oauthClientIdInput').value.trim() || (form.clientId ? form.clientId.value.trim() : '') || oauthDraft.clientId || null),
+                redirect_uri: 'http://localhost:1455/auth/callback'
+            })
+        });
+
+        if (!result.success) {
+            showToast(result.error || '解析回调失败', 'error');
+            return;
+        }
+
+        const data = result.data || {};
+        if (form.accessToken && data.access_token) form.accessToken.value = data.access_token;
+        if (form.refreshToken && data.refresh_token) form.refreshToken.value = data.refresh_token;
+        if (form.clientId && data.client_id) form.clientId.value = data.client_id;
+        if (data.client_id) document.getElementById('oauthClientIdInput').value = data.client_id;
+
+        showToast('已自动填充 Token 信息，请确认后导入', 'success');
+    } catch (error) {
+        showToast('解析回调失败', 'error');
+    }
+}
+
 async function handleSingleImport(event) {
     event.preventDefault();
     const form = event.target;

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -111,6 +111,22 @@
 
                 <div id="singleImport" class="import-panel">
                     <form id="singleImportForm" onsubmit="handleSingleImport(event)">
+                        <div class="form-group" style="padding: 0.75rem; border: 1px dashed var(--border); border-radius: 10px; margin-bottom: 1rem;">
+                            <label style="margin-bottom: 0.5rem; display: block;">一键获取 Token（实验功能）</label>
+                            <div class="input-group-btn" style="margin-bottom: 0.5rem;">
+                                <input type="text" id="oauthClientIdInput" class="form-control" placeholder="先填写 Client ID（app_xxx）">
+                                <button type="button" class="btn btn-secondary" onclick="generateOAuthAuthorizeLink()">生成授权链接</button>
+                            </div>
+                            <div class="input-group-btn" style="margin-bottom: 0.5rem;">
+                                <input type="text" id="oauthAuthorizeUrlOutput" class="form-control" placeholder="点击生成后会出现授权链接" readonly>
+                                <button type="button" class="btn btn-secondary" onclick="copyOAuthAuthorizeUrl()">复制链接</button>
+                            </div>
+                            <textarea id="oauthCallbackInput" class="form-control" rows="3" placeholder="登录后把完整回调 URL 粘贴到这里"></textarea>
+                            <div style="margin-top: 0.5rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
+                                <button type="button" class="btn btn-secondary" onclick="parseOAuthCallbackAndFill()">解析并自动填充</button>
+                                <small class="form-text" style="margin: 0; align-self: center;">支持直接解析 callback 中 token，或用 code + code_verifier 自动兑换。</small>
+                            </div>
+                        </div>
                         <div class="form-group">
                             <label>Access Token (AT) <span class="required">*</span></label>
                             <input type="text" name="accessToken" class="form-control"


### PR DESCRIPTION
### Motivation
- Provide an admin-facing helper to generate OAuth authorize URLs, parse OAuth callbacks (or exchange code with PKCE) and automatically populate AT/RT when importing Teams to simplify onboarding and token management.

### Description
- Added two admin endpoints `POST /admin/oauth/openai/authorize` and `POST /admin/oauth/openai/parse-callback` with request models `OAuthAuthorizeRequest` and `OAuthCallbackParseRequest` in `app/routes/admin.py` to generate PKCE authorize URLs and parse/exchange callback data.
- Extended `app/services/chatgpt.py` with `create_oauth_authorize_url` to build a PKCE authorize URL and `exchange_oauth_code` to exchange authorization codes for tokens, plus required imports and helpers; exposed `chatgpt_service` usage in the admin routes.
- Updated frontend assets in `app/static/js/main.js` to add `generateOAuthAuthorizeLink`, `copyOAuthAuthorizeUrl`, and `parseOAuthCallbackAndFill` functions and an `oauthDraft` state object to support the UI flow.
- Updated `app/templates/base.html` to add UI elements inside the Team import modal for generating the authorize link, pasting the callback URL, and automatically filling access/refresh tokens into the import form.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b28cb97c28832cad38f322f2770595)