### PR TITLE
Add JSON team import (streaming) and OAuth JSON export UI

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -337,6 +337,19 @@ async def team_import(
                 media_type="application/x-ndjson"
             )
 
+        elif import_data.import_type == "json":
+            async def progress_generator():
+                async for status_item in team_service.import_team_json(
+                    json_text=import_data.content,
+                    db_session=db
+                ):
+                    yield json.dumps(status_item, ensure_ascii=False) + "\n"
+
+            return StreamingResponse(
+                progress_generator(),
+                media_type="application/x-ndjson"
+            )
+
         else:
             return JSONResponse(
                 status_code=status.HTTP_400_BAD_REQUEST,

--- a/app/services/team.py
+++ b/app/services/team.py
@@ -3,6 +3,7 @@ Team 管理服务
 用于管理 Team 账号的导入、同步、成员管理等功能
 """
 import logging
+import json
 import asyncio
 from typing import Optional, Dict, Any, List
 from datetime import datetime, timedelta
@@ -893,6 +894,107 @@ class TeamService:
                 "type": "error",
                 "error": f"批量导入过程中发生异常: {str(e)}"
             }
+
+    async def import_team_json(
+        self,
+        json_text: Optional[str],
+        db_session: AsyncSession
+    ):
+        """从 JSON 文本批量导入 Team（流式返回进度）。"""
+        try:
+            if not json_text:
+                yield {"type": "error", "error": "JSON 内容不能为空"}
+                return
+
+            try:
+                payload = json.loads(json_text)
+            except Exception as e:
+                yield {"type": "error", "error": f"JSON 解析失败: {e}"}
+                return
+
+            raw_items = []
+            if isinstance(payload, list):
+                raw_items = payload
+            elif isinstance(payload, dict):
+                if isinstance(payload.get("teams"), list):
+                    raw_items = payload.get("teams")
+                else:
+                    raw_items = [payload]
+            else:
+                yield {"type": "error", "error": "JSON 顶层必须是对象或数组"}
+                return
+
+            normalized_items = []
+            for item in raw_items:
+                if not isinstance(item, dict):
+                    continue
+
+                access_token = item.get("access_token") or item.get("token")
+                refresh_token = item.get("refresh_token")
+                session_token = item.get("session_token")
+
+                if not any([access_token, refresh_token, session_token]):
+                    continue
+
+                normalized_items.append({
+                    "access_token": access_token,
+                    "refresh_token": refresh_token,
+                    "session_token": session_token,
+                    "client_id": item.get("client_id"),
+                    "email": item.get("email"),
+                    "account_id": item.get("account_id")
+                })
+
+            if not normalized_items:
+                yield {"type": "error", "error": "JSON 中未找到可导入的 Team 项（需包含 AT/RT/ST）"}
+                return
+
+            total = len(normalized_items)
+            yield {"type": "start", "total": total}
+
+            success_count = 0
+            failed_count = 0
+            for i, data in enumerate(normalized_items):
+                result = await self.import_team_single(
+                    access_token=data.get("access_token"),
+                    db_session=db_session,
+                    email=data.get("email"),
+                    account_id=data.get("account_id"),
+                    refresh_token=data.get("refresh_token"),
+                    session_token=data.get("session_token"),
+                    client_id=data.get("client_id")
+                )
+
+                if result["success"]:
+                    success_count += 1
+                else:
+                    failed_count += 1
+
+                yield {
+                    "type": "progress",
+                    "current": i + 1,
+                    "total": total,
+                    "success_count": success_count,
+                    "failed_count": failed_count,
+                    "last_result": {
+                        "email": result.get("email") or data.get("email") or "未知",
+                        "account_id": data.get("account_id", "未指定"),
+                        "success": result["success"],
+                        "team_id": result["team_id"],
+                        "message": result["message"],
+                        "error": result["error"]
+                    }
+                }
+
+            yield {
+                "type": "finish",
+                "total": total,
+                "success_count": success_count,
+                "failed_count": failed_count
+            }
+        except Exception as e:
+            logger.error(f"JSON 导入失败: {e}")
+            yield {"type": "error", "error": f"JSON 导入过程中发生异常: {str(e)}"}
 
     async def sync_team_info(
         self,

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -110,6 +110,13 @@ document.addEventListener('DOMContentLoaded', function () {
             parseOAuthCallbackAndFill();
         });
     }
+
+    const btnExportOAuthJson = document.getElementById('btnExportOAuthJson');
+    if (btnExportOAuthJson) {
+        btnExportOAuthJson.addEventListener('click', () => {
+            exportOAuthJsonTemplateFile();
+        });
+    }
 });
 
 // 检查认证状态
@@ -282,42 +289,123 @@ async function generateOAuthAuthorizeLink() {
     }
 }
 
-async function parseOAuthCallbackAndFill() {
+async function parseOAuthCallbackData() {
     const callbackText = document.getElementById('oauthCallbackInput').value.trim();
     const form = document.getElementById('singleImportForm');
 
     if (!callbackText) {
-        showToast('请先粘贴回调 URL', 'error');
-        return;
+        throw new Error('请先粘贴回调 URL');
     }
 
+    const result = await apiCall('/admin/oauth/openai/parse-callback', {
+        method: 'POST',
+        body: JSON.stringify({
+            callback_text: callbackText,
+            code_verifier: oauthDraft.codeVerifier || null,
+            expected_state: oauthDraft.state || null,
+            client_id: ((form.clientId ? form.clientId.value.trim() : '') || oauthDraft.clientId || 'app_EMoamEEZ73f0CkXaXp7hrann'),
+            redirect_uri: 'http://localhost:1455/auth/callback'
+        })
+    });
+
+    if (!result.success) {
+        throw new Error(result.error || '解析回调失败');
+    }
+
+    return unwrapApiPayload(result) || {};
+}
+
+function decodeJwtPayload(token) {
+    if (!token || typeof token !== 'string') return null;
+    const parts = token.split('.');
+    if (parts.length < 2) return null;
+
     try {
-        const result = await apiCall('/admin/oauth/openai/parse-callback', {
-            method: 'POST',
-            body: JSON.stringify({
-                callback_text: callbackText,
-                code_verifier: oauthDraft.codeVerifier || null,
-                expected_state: oauthDraft.state || null,
-                client_id: ((form.clientId ? form.clientId.value.trim() : '') || oauthDraft.clientId || 'app_EMoamEEZ73f0CkXaXp7hrann'),
-                redirect_uri: 'http://localhost:1455/auth/callback'
-            })
-        });
+        const base64Url = parts[1];
+        const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+        const padded = base64.padEnd(base64.length + (4 - base64.length % 4) % 4, '=');
+        const jsonText = decodeURIComponent(escape(window.atob(padded)));
+        return JSON.parse(jsonText);
+    } catch (error) {
+        return null;
+    }
+}
 
-        if (!result.success) {
-            showToast(result.error || '解析回调失败', 'error');
-            return;
-        }
+function toIsoStringWithOffset8(dateObj) {
+    if (!(dateObj instanceof Date) || Number.isNaN(dateObj.getTime())) return '';
+    const shifted = new Date(dateObj.getTime() + 8 * 60 * 60 * 1000);
+    const iso = shifted.toISOString().replace('Z', '+08:00');
+    return iso.slice(0, 19) + '+08:00';
+}
 
-        const data = unwrapApiPayload(result) || {};
+function buildOAuthJsonTemplate(parsedData) {
+    const accessToken = parsedData.access_token || '';
+    const refreshToken = parsedData.refresh_token || '';
+    const clientId = parsedData.client_id || '';
+    const raw = parsedData.raw || {};
+
+    const accessPayload = decodeJwtPayload(accessToken) || {};
+    const accessAuth = accessPayload['https://api.openai.com/auth'] || {};
+    const accessProfile = accessPayload['https://api.openai.com/profile'] || {};
+
+    const accountId = raw.account_id || accessAuth.chatgpt_account_id || '';
+    const email = raw.email || accessProfile.email || '';
+    const exp = accessPayload.exp ? new Date(accessPayload.exp * 1000) : null;
+
+    return {
+        access_token: accessToken,
+        account_id: accountId,
+        disabled: false,
+        email,
+        expired: exp ? toIsoStringWithOffset8(exp) : '',
+        id_token: raw.id_token || '',
+        last_refresh: toIsoStringWithOffset8(new Date()),
+        refresh_token: refreshToken,
+        type: 'codex',
+        client_id: clientId
+    };
+}
+
+function downloadJsonFile(payload, filename) {
+    const text = JSON.stringify(payload, null, 2);
+    const blob = new Blob([text], { type: 'application/json;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+}
+
+async function exportOAuthJsonTemplateFile() {
+    try {
+        const data = await parseOAuthCallbackData();
+        const payload = buildOAuthJsonTemplate(data);
+        const filename = `team-oauth-${Date.now()}.json`;
+        downloadJsonFile(payload, filename);
+        showToast('JSON 文件已导出', 'success');
+    } catch (error) {
+        showToast(error.message || '导出 JSON 失败', 'error');
+    }
+}
+
+async function parseOAuthCallbackAndFill() {
+    const form = document.getElementById('singleImportForm');
+
+    try {
+        const data = await parseOAuthCallbackData();
         if (form.accessToken && data.access_token) form.accessToken.value = data.access_token;
         if (form.refreshToken && data.refresh_token) form.refreshToken.value = data.refresh_token;
         if (form.clientId && data.client_id) form.clientId.value = data.client_id;
 
         showToast('已自动填充 Token 信息，请确认后导入', 'success');
     } catch (error) {
-        showToast('解析回调失败', 'error');
+        showToast(error.message || '解析回调失败', 'error');
     }
 }
+
 
 async function handleSingleImport(event) {
     event.preventDefault();
@@ -481,6 +569,143 @@ async function handleBatchImport(event) {
     } finally {
         submitButton.disabled = false;
         submitButton.textContent = '批量导入';
+    }
+}
+
+async function handleJsonFileImport() {
+    const fileInput = document.getElementById('jsonImportFile');
+    const form = document.getElementById('batchImportForm');
+    const submitButton = form ? form.querySelector('button[type="submit"]') : null;
+
+    if (!fileInput || !fileInput.files || fileInput.files.length === 0) {
+        showToast('请先选择 JSON 文件', 'error');
+        return;
+    }
+
+    const file = fileInput.files[0];
+    let content = '';
+    try {
+        content = await file.text();
+        JSON.parse(content);
+    } catch (error) {
+        showToast('JSON 文件格式无效', 'error');
+        return;
+    }
+
+    if (submitButton) {
+        submitButton.disabled = true;
+        submitButton.textContent = 'JSON 导入中...';
+    }
+
+    // UI 元素
+    const progressContainer = document.getElementById('batchProgressContainer');
+    const progressBar = document.getElementById('batchProgressBar');
+    const progressStage = document.getElementById('batchProgressStage');
+    const progressPercent = document.getElementById('batchProgressPercent');
+    const successCountEl = document.getElementById('batchSuccessCount');
+    const failedCountEl = document.getElementById('batchFailedCount');
+    const resultsContainer = document.getElementById('batchResultsContainer');
+    const resultsDiv = document.getElementById('batchResults');
+    const finalSummaryEl = document.getElementById('batchFinalSummary');
+
+    // 重置 UI
+    progressContainer.style.display = 'block';
+    resultsContainer.style.display = 'none';
+    progressBar.style.width = '0%';
+    progressStage.textContent = '准备 JSON 导入...';
+    progressPercent.textContent = '0%';
+    successCountEl.textContent = '0';
+    failedCountEl.textContent = '0';
+    resultsDiv.innerHTML = '<table class="data-table"><thead><tr><th>邮箱</th><th>状态</th><th>消息</th></tr></thead><tbody id="batchResultsBody"></tbody></table>';
+    const resultsBody = document.getElementById('batchResultsBody');
+
+    try {
+        const response = await fetch('/admin/teams/import', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                import_type: 'json',
+                content
+            })
+        });
+
+        if (!response.ok) {
+            const errorData = await response.json();
+            throw new Error(errorData.error || errorData.detail || '请求失败');
+        }
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+
+        while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+
+            buffer += decoder.decode(value, { stream: true });
+            const lines = buffer.split('\n');
+            buffer = lines.pop();
+
+            for (const line of lines) {
+                if (!line.trim()) continue;
+                try {
+                    const data = JSON.parse(line);
+
+                    if (data.type === 'start') {
+                        progressStage.textContent = `开始导入 (共 ${data.total} 条)...`;
+                    } else if (data.type === 'progress') {
+                        const percent = Math.round((data.current / data.total) * 100);
+                        progressBar.style.width = `${percent}%`;
+                        progressPercent.textContent = `${percent}%`;
+                        progressStage.textContent = `正在导入 ${data.current}/${data.total}...`;
+                        successCountEl.textContent = data.success_count;
+                        failedCountEl.textContent = data.failed_count;
+
+                        if (data.last_result) {
+                            resultsContainer.style.display = 'block';
+                            const res = data.last_result;
+                            const statusClass = res.success ? 'text-success' : 'text-danger';
+                            const statusText = res.success ? '成功' : '失败';
+                            const row = document.createElement('tr');
+                            row.innerHTML = `
+                                <td>${res.email}</td>
+                                <td class="${statusClass}">${statusText}</td>
+                                <td>${res.success ? (res.message || '导入成功') : res.error}</td>
+                            `;
+                            resultsBody.insertBefore(row, resultsBody.firstChild);
+                        }
+                    } else if (data.type === 'finish') {
+                        progressStage.textContent = '导入完成';
+                        progressBar.style.width = '100%';
+                        progressPercent.textContent = '100%';
+                        finalSummaryEl.textContent = `总数: ${data.total} | 成功: ${data.success_count} | 失败: ${data.failed_count}`;
+
+                        if (data.failed_count === 0) {
+                            showToast('全部导入成功！', 'success');
+                        } else {
+                            showToast(`导入完成，成功 ${data.success_count} 条，失败 ${data.failed_count} 条`, 'warning');
+                        }
+
+                        if (data.success_count > 0) {
+                            setTimeout(() => location.reload(), 3000);
+                        }
+                    } else if (data.type === 'error') {
+                        showToast(data.error, 'error');
+                    }
+                } catch (e) {
+                    console.error('解析流数据失败:', e, line);
+                }
+            }
+        }
+    } catch (error) {
+        showToast(error.message || '网络错误', 'error');
+    } finally {
+        if (submitButton) {
+            submitButton.disabled = false;
+            submitButton.textContent = '批量导入';
+        }
     }
 }
 
@@ -832,4 +1057,6 @@ async function deleteMember(teamId, userId, email, inModal = false) {
 if (typeof window !== 'undefined') {
     window.generateOAuthAuthorizeLink = generateOAuthAuthorizeLink;
     window.parseOAuthCallbackAndFill = parseOAuthCallbackAndFill;
+    window.exportOAuthJsonTemplateFile = exportOAuthJsonTemplateFile;
+    window.handleJsonFileImport = handleJsonFileImport;
 }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -121,7 +121,8 @@
                             <textarea id="oauthCallbackInput" class="form-control" rows="3" placeholder="登录后把完整回调 URL 粘贴到这里"></textarea>
                             <div style="margin-top: 0.5rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
                                 <button type="button" id="btnParseOAuthCallback" class="btn btn-secondary">解析并自动填充</button>
-                                <small class="form-text" style="margin: 0; align-self: center;">粘贴回调后自动解析并填充 AT / RT / Client ID。</small>
+                                <button type="button" id="btnExportOAuthJson" class="btn btn-secondary">导出 JSON 文件</button>
+                                <small class="form-text" style="margin: 0; align-self: center;">粘贴回调后可自动填充 AT / RT / Client ID，或导出 JSON 模板文件。</small>
                             </div>
                         </div>
                         <div class="form-group">
@@ -162,6 +163,14 @@
 
                 <div id="batchImport" class="import-panel" style="display: none;">
                     <form id="batchImportForm" onsubmit="handleBatchImport(event)">
+                        <div class="form-group" style="padding: 0.75rem; border: 1px dashed var(--border); border-radius: 10px; margin-bottom: 1rem;">
+                            <label style="margin-bottom: 0.5rem; display: block;">JSON 文件导入</label>
+                            <div style="display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center;">
+                                <input type="file" id="jsonImportFile" accept=".json,application/json" class="form-control" style="max-width: 300px;">
+                                <button type="button" class="btn btn-secondary" onclick="handleJsonFileImport()">导入 JSON</button>
+                                <small class="form-text" style="margin: 0;">支持单对象、对象数组，或 {"teams": [...]} 格式。</small>
+                            </div>
+                        </div>
                         <div class="form-group">
                             <label>批量导入内容 <span class="required">*</span></label>
                             <textarea name="batchContent" class="form-control" rows="8" placeholder="一行一个 AT Token..."


### PR DESCRIPTION
### Motivation
- Provide a convenient way to import Team accounts from a structured JSON payload in addition to the existing single/token and line-based batch imports.
- Allow administrators to export a parsed OAuth callback into a JSON template file for easier bulk onboarding and record keeping.

### Description
- Added `import_type == "json"` handling in the admin import route to return a `StreamingResponse` with NDJSON progress events.
- Implemented `TeamService.import_team_json` to parse JSON input (single object, object with `teams` array, or array), normalize token fields, and stream `start`/`progress`/`finish`/`error` events while calling `import_team_single` for each item.
- Extended the frontend `app/static/js/main.js` with OAuth parsing/refactor utilities (`parseOAuthCallbackData`, `decodeJwtPayload`, `buildOAuthJsonTemplate`, `exportOAuthJsonTemplateFile`) and added `handleJsonFileImport` to upload a JSON file, POST `import_type: 'json'`, and stream progress into the UI.
- Updated `app/templates/base.html` to add UI elements for exporting OAuth JSON and selecting/importing a JSON file for batch import, and exposed new functions on `window`.

### Testing
- Ran the project test suite locally using `pytest`, and the tests completed successfully.
- Ran static checks/linting (`flake8`) with no new issues reported.
- Performed an automated smoke test of the JSON import streaming endpoint by POSTing a sample JSON payload and confirming NDJSON progress messages were returned.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b3d74d5c58832f862cbf42d35f4f1c)