### PR TITLE
Add JSON team import and OAuth JSON export; UI/UX improvements for redeem and admin flows

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -337,6 +337,19 @@ async def team_import(
                 media_type="application/x-ndjson"
             )
 
+        elif import_data.import_type == "json":
+            async def progress_generator():
+                async for status_item in team_service.import_team_json(
+                    json_text=import_data.content,
+                    db_session=db
+                ):
+                    yield json.dumps(status_item, ensure_ascii=False) + "\n"
+
+            return StreamingResponse(
+                progress_generator(),
+                media_type="application/x-ndjson"
+            )
+
         else:
             return JSONResponse(
                 status_code=status.HTTP_400_BAD_REQUEST,

--- a/app/services/team.py
+++ b/app/services/team.py
@@ -3,6 +3,7 @@ Team 管理服务
 用于管理 Team 账号的导入、同步、成员管理等功能
 """
 import logging
+import json
 import asyncio
 from typing import Optional, Dict, Any, List
 from datetime import datetime, timedelta
@@ -893,6 +894,107 @@ class TeamService:
                 "type": "error",
                 "error": f"批量导入过程中发生异常: {str(e)}"
             }
+
+    async def import_team_json(
+        self,
+        json_text: Optional[str],
+        db_session: AsyncSession
+    ):
+        """从 JSON 文本批量导入 Team（流式返回进度）。"""
+        try:
+            if not json_text:
+                yield {"type": "error", "error": "JSON 内容不能为空"}
+                return
+
+            try:
+                payload = json.loads(json_text)
+            except Exception as e:
+                yield {"type": "error", "error": f"JSON 解析失败: {e}"}
+                return
+
+            raw_items = []
+            if isinstance(payload, list):
+                raw_items = payload
+            elif isinstance(payload, dict):
+                if isinstance(payload.get("teams"), list):
+                    raw_items = payload.get("teams")
+                else:
+                    raw_items = [payload]
+            else:
+                yield {"type": "error", "error": "JSON 顶层必须是对象或数组"}
+                return
+
+            normalized_items = []
+            for item in raw_items:
+                if not isinstance(item, dict):
+                    continue
+
+                access_token = item.get("access_token") or item.get("token")
+                refresh_token = item.get("refresh_token")
+                session_token = item.get("session_token")
+
+                if not any([access_token, refresh_token, session_token]):
+                    continue
+
+                normalized_items.append({
+                    "access_token": access_token,
+                    "refresh_token": refresh_token,
+                    "session_token": session_token,
+                    "client_id": item.get("client_id"),
+                    "email": item.get("email"),
+                    "account_id": item.get("account_id")
+                })
+
+            if not normalized_items:
+                yield {"type": "error", "error": "JSON 中未找到可导入的 Team 项（需包含 AT/RT/ST）"}
+                return
+
+            total = len(normalized_items)
+            yield {"type": "start", "total": total}
+
+            success_count = 0
+            failed_count = 0
+            for i, data in enumerate(normalized_items):
+                result = await self.import_team_single(
+                    access_token=data.get("access_token"),
+                    db_session=db_session,
+                    email=data.get("email"),
+                    account_id=data.get("account_id"),
+                    refresh_token=data.get("refresh_token"),
+                    session_token=data.get("session_token"),
+                    client_id=data.get("client_id")
+                )
+
+                if result["success"]:
+                    success_count += 1
+                else:
+                    failed_count += 1
+
+                yield {
+                    "type": "progress",
+                    "current": i + 1,
+                    "total": total,
+                    "success_count": success_count,
+                    "failed_count": failed_count,
+                    "last_result": {
+                        "email": result.get("email") or data.get("email") or "未知",
+                        "account_id": data.get("account_id", "未指定"),
+                        "success": result["success"],
+                        "team_id": result["team_id"],
+                        "message": result["message"],
+                        "error": result["error"]
+                    }
+                }
+
+            yield {
+                "type": "finish",
+                "total": total,
+                "success_count": success_count,
+                "failed_count": failed_count
+            }
+        except Exception as e:
+            logger.error(f"JSON 导入失败: {e}")
+            yield {"type": "error", "error": f"JSON 导入过程中发生异常: {str(e)}"}
 
     async def sync_team_info(
         self,

--- a/app/static/css/user.css
+++ b/app/static/css/user.css
@@ -1,123 +1,122 @@
-/* User Redeem Page Design System */
 :root {
     --primary: #6366f1;
     --primary-hover: #4f46e5;
     --primary-soft: #eef2ff;
-
-    --bg-main: #f9fafb;
+    --bg-main: #f5f7ff;
     --bg-surface: #ffffff;
-
     --text-main: #0f172a;
     --text-muted: #64748b;
-    --text-dim: #94a3b8;
-
-    --border-base: #e2e8f0;
-
+    --border-base: #dbe3f1;
     --success: #10b981;
-    --success-soft: #ecfdf5;
     --danger: #ef4444;
-    --danger-soft: #fef2f2;
-
-    --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-    --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-    --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
-
-    --radius-md: 10px;
-    --radius-lg: 16px;
+    --shadow-md: 0 10px 30px rgb(15 23 42 / 0.08);
+    --radius-md: 12px;
+    --radius-lg: 20px;
     --radius-full: 9999px;
-
-    --transition-base: 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    --transition-base: 0.2s ease;
 }
 
-* {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-}
+* { margin: 0; padding: 0; box-sizing: border-box; }
 
 body {
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, inherit;
-    background-color: var(--bg-main);
+    background:
+        radial-gradient(circle at 10% 0%, #e8edff 0%, transparent 45%),
+        radial-gradient(circle at 90% 10%, #f0f9ff 0%, transparent 42%),
+        var(--bg-main);
     color: var(--text-main);
     min-height: 100vh;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 1.5rem;
-    line-height: 1.5;
+    padding: 2rem;
+    line-height: 1.55;
 }
 
-.container {
-    max-width: 480px;
+.container.full-layout {
     width: 100%;
+    max-width: 1280px;
+    margin: 0 auto;
 }
 
-.header {
-    text-align: center;
-    margin-bottom: 2.5rem;
-}
+.full-header { text-align: center; margin-bottom: 1rem; }
 
 .header h1 {
-    font-size: 2rem;
-    font-weight: 800;
-    letter-spacing: -0.025em;
-    color: var(--text-main);
-    margin-bottom: 0.5rem;
+    font-size: clamp(2.1rem, 4.2vw, 3rem);
+    font-weight: 900;
+    letter-spacing: -0.03em;
+    margin-bottom: 0.3rem;
 }
 
-.subtitle {
-    font-size: 1rem;
+.subtitle { font-size: 1.02rem; color: var(--text-muted); }
+
+.top-nav-tabs {
+    display: flex;
+    justify-content: center;
+    gap: 0.8rem;
+    margin: 1.3rem auto 1.8rem;
+    flex-wrap: wrap;
+}
+
+.top-tab {
+    border: 1px solid var(--border-base);
+    background: rgb(255 255 255 / 0.75);
+    backdrop-filter: blur(8px);
     color: var(--text-muted);
+    border-radius: var(--radius-full);
+    padding: 0.72rem 1.25rem;
+    font-size: 0.95rem;
+    font-weight: 700;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    cursor: pointer;
+    transition: var(--transition-base);
 }
 
-.card {
-    background-color: var(--bg-surface);
+.top-tab.active {
+    background: linear-gradient(90deg, var(--primary), #7c83ff);
+    color: #fff;
+    border-color: transparent;
+    box-shadow: var(--shadow-md);
+}
+
+.step { display: none; }
+.step.active { display: block; }
+.tab-panel { display: none; }
+.tab-panel.active { display: block; }
+
+.surface-panel {
+    width: min(100%, 1200px);
+    margin: 0 auto;
+    background: var(--bg-surface);
     border: 1px solid var(--border-base);
     border-radius: var(--radius-lg);
-    padding: 2rem;
-    box-shadow: var(--shadow-lg);
-    animation: slideUp 0.4s ease-out;
+    padding: clamp(1.4rem, 2.5vw, 2.2rem);
+    box-shadow: var(--shadow-md);
 }
 
-@keyframes slideUp {
-    from {
-        opacity: 0;
-        transform: translateY(20px);
-    }
-
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-.card h2 {
-    font-size: 1.25rem;
-    font-weight: 700;
-    margin-bottom: 1.5rem;
+.surface-panel h2 {
+    font-size: 1.42rem;
+    font-weight: 800;
+    margin-bottom: 1.1rem;
     text-align: center;
 }
 
-.form-group {
-    margin-bottom: 1.5rem;
-}
-
+.form-group { margin-bottom: 1.15rem; }
 .form-group label {
     display: block;
-    font-size: 0.875rem;
-    font-weight: 600;
-    margin-bottom: 0.5rem;
-    color: var(--text-main);
+    font-size: 0.88rem;
+    font-weight: 700;
+    margin-bottom: 0.45rem;
 }
 
 .form-input {
     width: 100%;
-    padding: 0.75rem 1rem;
+    padding: 0.84rem 1rem;
     border: 1px solid var(--border-base);
     border-radius: var(--radius-md);
     font-size: 1rem;
     transition: var(--transition-base);
     outline: none;
+    background: #fff;
 }
 
 .form-input:focus {
@@ -125,15 +124,11 @@ body {
     box-shadow: 0 0 0 4px var(--primary-soft);
 }
 
-.form-help {
-    font-size: 0.75rem;
-    color: var(--text-muted);
-    margin-top: 0.375rem;
-}
+.form-help { font-size: 0.83rem; color: var(--text-muted); margin-top: 0.34rem; }
 
 .btn {
     width: 100%;
-    padding: 0.75rem;
+    padding: 0.82rem;
     border: none;
     border-radius: var(--radius-md);
     font-size: 1rem;
@@ -143,89 +138,42 @@ body {
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 0.5rem;
+    gap: 0.45rem;
 }
 
-.btn-primary {
-    background-color: var(--primary);
-    color: white;
-}
+.btn-primary { background: linear-gradient(90deg, var(--primary), #7c83ff); color: #fff; }
+.btn-primary:hover { transform: translateY(-1px); }
+.btn-secondary { background: #fff; color: var(--text-main); border: 1px solid var(--border-base); }
+.btn-secondary:hover { background: #f8fafc; }
 
-.btn-primary:hover {
-    background-color: var(--primary-hover);
-    transform: translateY(-1px);
-}
-
-.btn-primary:active {
-    transform: translateY(0);
-}
-
-/* Toast */
 .toast {
     position: fixed;
-    top: 2rem;
-    right: 2rem;
-    padding: 1rem 1.5rem;
+    top: 1.2rem;
+    right: 1.2rem;
+    padding: 0.85rem 1rem;
     background: white;
     border-radius: var(--radius-md);
-    box-shadow: var(--shadow-lg);
+    box-shadow: var(--shadow-md);
     border: 1px solid var(--border-base);
     display: none;
     z-index: 100;
 }
+.toast.show { display: block; }
+.toast.success { border-left: 4px solid var(--success); }
+.toast.error { border-left: 4px solid var(--danger); }
 
-.toast.show {
-    display: block;
-}
-
-.toast.success {
-    border-left: 4px solid var(--success);
-}
-
-.toast.error {
-    border-left: 4px solid var(--danger);
-}
-
-/* Steps */
-.step {
-    display: none;
-}
-
-.step.active {
-    display: block;
-}
-
-/* Result */
-.result-success {
-    text-align: center;
-}
-
-.result-error {
-    text-align: center;
-}
-
-.result-icon {
-    font-size: 3rem;
-    margin-bottom: 1rem;
-}
-
-.result-title {
-    font-size: 1.5rem;
-    font-weight: 800;
-    margin-bottom: 0.5rem;
-}
-
-.result-message {
-    color: var(--text-muted);
-    margin-bottom: 2rem;
-}
+.result-success,
+.result-error { text-align: center; }
+.result-icon { font-size: 3rem; margin-bottom: 1rem; }
+.result-title { font-size: 1.5rem; font-weight: 800; margin-bottom: 0.5rem; }
+.result-message { color: var(--text-muted); margin-bottom: 1.2rem; }
 
 .result-details {
-    background-color: var(--bg-main);
+    background-color: #f8fafc;
     border-radius: var(--radius-md);
     padding: 1rem;
     text-align: left;
-    margin-bottom: 2rem;
+    margin-bottom: 1.2rem;
 }
 
 .result-detail-item {
@@ -234,46 +182,13 @@ body {
     padding: 0.75rem 0;
     border-bottom: 1px solid var(--border-base);
 }
+.result-detail-item:last-child { border-bottom: none; }
+.result-detail-label { font-size: 0.875rem; color: var(--text-muted); }
+.result-detail-value { font-size: 0.875rem; font-weight: 600; }
 
-.result-detail-item:last-child {
-    border-bottom: none;
-}
-
-.result-detail-label {
-    font-size: 0.875rem;
-    color: var(--text-muted);
-}
-
-.result-detail-value {
-    font-size: 0.875rem;
-    font-weight: 600;
-}
-
-/* Mobile Responsiveness */
-@media (max-width: 480px) {
-    body {
-        padding: 1rem;
-    }
-
-    .header {
-        margin-bottom: 1.5rem;
-    }
-
-    .header h1 {
-        font-size: 1.5rem;
-    }
-
-    .card {
-        padding: 1.5rem;
-    }
-
-    .toast {
-        left: 1rem;
-        right: 1rem;
-        top: 1rem;
-    }
-
-    .result-title {
-        font-size: 1.25rem;
-    }
+@media (max-width: 768px) {
+    body { padding: 1rem; }
+    .top-tab { flex: 1; justify-content: center; min-width: 140px; }
+    .surface-panel { border-radius: 14px; }
+    .toast { left: 1rem; right: 1rem; top: 1rem; }
 }

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -110,6 +110,13 @@ document.addEventListener('DOMContentLoaded', function () {
             parseOAuthCallbackAndFill();
         });
     }
+
+    const btnExportOAuthJson = document.getElementById('btnExportOAuthJson');
+    if (btnExportOAuthJson) {
+        btnExportOAuthJson.addEventListener('click', () => {
+            exportOAuthJsonTemplateFile();
+        });
+    }
 });
 
 // 检查认证状态
@@ -282,42 +289,123 @@ async function generateOAuthAuthorizeLink() {
     }
 }
 
-async function parseOAuthCallbackAndFill() {
+async function parseOAuthCallbackData() {
     const callbackText = document.getElementById('oauthCallbackInput').value.trim();
     const form = document.getElementById('singleImportForm');
 
     if (!callbackText) {
-        showToast('请先粘贴回调 URL', 'error');
-        return;
+        throw new Error('请先粘贴回调 URL');
     }
 
+    const result = await apiCall('/admin/oauth/openai/parse-callback', {
+        method: 'POST',
+        body: JSON.stringify({
+            callback_text: callbackText,
+            code_verifier: oauthDraft.codeVerifier || null,
+            expected_state: oauthDraft.state || null,
+            client_id: ((form.clientId ? form.clientId.value.trim() : '') || oauthDraft.clientId || 'app_EMoamEEZ73f0CkXaXp7hrann'),
+            redirect_uri: 'http://localhost:1455/auth/callback'
+        })
+    });
+
+    if (!result.success) {
+        throw new Error(result.error || '解析回调失败');
+    }
+
+    return unwrapApiPayload(result) || {};
+}
+
+function decodeJwtPayload(token) {
+    if (!token || typeof token !== 'string') return null;
+    const parts = token.split('.');
+    if (parts.length < 2) return null;
+
     try {
-        const result = await apiCall('/admin/oauth/openai/parse-callback', {
-            method: 'POST',
-            body: JSON.stringify({
-                callback_text: callbackText,
-                code_verifier: oauthDraft.codeVerifier || null,
-                expected_state: oauthDraft.state || null,
-                client_id: ((form.clientId ? form.clientId.value.trim() : '') || oauthDraft.clientId || 'app_EMoamEEZ73f0CkXaXp7hrann'),
-                redirect_uri: 'http://localhost:1455/auth/callback'
-            })
-        });
+        const base64Url = parts[1];
+        const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+        const padded = base64.padEnd(base64.length + (4 - base64.length % 4) % 4, '=');
+        const jsonText = decodeURIComponent(escape(window.atob(padded)));
+        return JSON.parse(jsonText);
+    } catch (error) {
+        return null;
+    }
+}
 
-        if (!result.success) {
-            showToast(result.error || '解析回调失败', 'error');
-            return;
-        }
+function toIsoStringWithOffset8(dateObj) {
+    if (!(dateObj instanceof Date) || Number.isNaN(dateObj.getTime())) return '';
+    const shifted = new Date(dateObj.getTime() + 8 * 60 * 60 * 1000);
+    const iso = shifted.toISOString().replace('Z', '+08:00');
+    return iso.slice(0, 19) + '+08:00';
+}
 
-        const data = unwrapApiPayload(result) || {};
+function buildOAuthJsonTemplate(parsedData) {
+    const accessToken = parsedData.access_token || '';
+    const refreshToken = parsedData.refresh_token || '';
+    const clientId = parsedData.client_id || '';
+    const raw = parsedData.raw || {};
+
+    const accessPayload = decodeJwtPayload(accessToken) || {};
+    const accessAuth = accessPayload['https://api.openai.com/auth'] || {};
+    const accessProfile = accessPayload['https://api.openai.com/profile'] || {};
+
+    const accountId = raw.account_id || accessAuth.chatgpt_account_id || '';
+    const email = raw.email || accessProfile.email || '';
+    const exp = accessPayload.exp ? new Date(accessPayload.exp * 1000) : null;
+
+    return {
+        access_token: accessToken,
+        account_id: accountId,
+        disabled: false,
+        email,
+        expired: exp ? toIsoStringWithOffset8(exp) : '',
+        id_token: raw.id_token || '',
+        last_refresh: toIsoStringWithOffset8(new Date()),
+        refresh_token: refreshToken,
+        type: 'codex',
+        client_id: clientId
+    };
+}
+
+function downloadJsonFile(payload, filename) {
+    const text = JSON.stringify(payload, null, 2);
+    const blob = new Blob([text], { type: 'application/json;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+}
+
+async function exportOAuthJsonTemplateFile() {
+    try {
+        const data = await parseOAuthCallbackData();
+        const payload = buildOAuthJsonTemplate(data);
+        const filename = `team-oauth-${Date.now()}.json`;
+        downloadJsonFile(payload, filename);
+        showToast('JSON 文件已导出', 'success');
+    } catch (error) {
+        showToast(error.message || '导出 JSON 失败', 'error');
+    }
+}
+
+async function parseOAuthCallbackAndFill() {
+    const form = document.getElementById('singleImportForm');
+
+    try {
+        const data = await parseOAuthCallbackData();
         if (form.accessToken && data.access_token) form.accessToken.value = data.access_token;
         if (form.refreshToken && data.refresh_token) form.refreshToken.value = data.refresh_token;
         if (form.clientId && data.client_id) form.clientId.value = data.client_id;
 
         showToast('已自动填充 Token 信息，请确认后导入', 'success');
     } catch (error) {
-        showToast('解析回调失败', 'error');
+        showToast(error.message || '解析回调失败', 'error');
     }
 }
+
 
 async function handleSingleImport(event) {
     event.preventDefault();
@@ -481,6 +569,143 @@ async function handleBatchImport(event) {
     } finally {
         submitButton.disabled = false;
         submitButton.textContent = '批量导入';
+    }
+}
+
+async function handleJsonFileImport() {
+    const fileInput = document.getElementById('jsonImportFile');
+    const form = document.getElementById('batchImportForm');
+    const submitButton = form ? form.querySelector('button[type="submit"]') : null;
+
+    if (!fileInput || !fileInput.files || fileInput.files.length === 0) {
+        showToast('请先选择 JSON 文件', 'error');
+        return;
+    }
+
+    const file = fileInput.files[0];
+    let content = '';
+    try {
+        content = await file.text();
+        JSON.parse(content);
+    } catch (error) {
+        showToast('JSON 文件格式无效', 'error');
+        return;
+    }
+
+    if (submitButton) {
+        submitButton.disabled = true;
+        submitButton.textContent = 'JSON 导入中...';
+    }
+
+    // UI 元素
+    const progressContainer = document.getElementById('batchProgressContainer');
+    const progressBar = document.getElementById('batchProgressBar');
+    const progressStage = document.getElementById('batchProgressStage');
+    const progressPercent = document.getElementById('batchProgressPercent');
+    const successCountEl = document.getElementById('batchSuccessCount');
+    const failedCountEl = document.getElementById('batchFailedCount');
+    const resultsContainer = document.getElementById('batchResultsContainer');
+    const resultsDiv = document.getElementById('batchResults');
+    const finalSummaryEl = document.getElementById('batchFinalSummary');
+
+    // 重置 UI
+    progressContainer.style.display = 'block';
+    resultsContainer.style.display = 'none';
+    progressBar.style.width = '0%';
+    progressStage.textContent = '准备 JSON 导入...';
+    progressPercent.textContent = '0%';
+    successCountEl.textContent = '0';
+    failedCountEl.textContent = '0';
+    resultsDiv.innerHTML = '<table class="data-table"><thead><tr><th>邮箱</th><th>状态</th><th>消息</th></tr></thead><tbody id="batchResultsBody"></tbody></table>';
+    const resultsBody = document.getElementById('batchResultsBody');
+
+    try {
+        const response = await fetch('/admin/teams/import', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                import_type: 'json',
+                content
+            })
+        });
+
+        if (!response.ok) {
+            const errorData = await response.json();
+            throw new Error(errorData.error || errorData.detail || '请求失败');
+        }
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+
+        while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+
+            buffer += decoder.decode(value, { stream: true });
+            const lines = buffer.split('\n');
+            buffer = lines.pop();
+
+            for (const line of lines) {
+                if (!line.trim()) continue;
+                try {
+                    const data = JSON.parse(line);
+
+                    if (data.type === 'start') {
+                        progressStage.textContent = `开始导入 (共 ${data.total} 条)...`;
+                    } else if (data.type === 'progress') {
+                        const percent = Math.round((data.current / data.total) * 100);
+                        progressBar.style.width = `${percent}%`;
+                        progressPercent.textContent = `${percent}%`;
+                        progressStage.textContent = `正在导入 ${data.current}/${data.total}...`;
+                        successCountEl.textContent = data.success_count;
+                        failedCountEl.textContent = data.failed_count;
+
+                        if (data.last_result) {
+                            resultsContainer.style.display = 'block';
+                            const res = data.last_result;
+                            const statusClass = res.success ? 'text-success' : 'text-danger';
+                            const statusText = res.success ? '成功' : '失败';
+                            const row = document.createElement('tr');
+                            row.innerHTML = `
+                                <td>${res.email}</td>
+                                <td class="${statusClass}">${statusText}</td>
+                                <td>${res.success ? (res.message || '导入成功') : res.error}</td>
+                            `;
+                            resultsBody.insertBefore(row, resultsBody.firstChild);
+                        }
+                    } else if (data.type === 'finish') {
+                        progressStage.textContent = '导入完成';
+                        progressBar.style.width = '100%';
+                        progressPercent.textContent = '100%';
+                        finalSummaryEl.textContent = `总数: ${data.total} | 成功: ${data.success_count} | 失败: ${data.failed_count}`;
+
+                        if (data.failed_count === 0) {
+                            showToast('全部导入成功！', 'success');
+                        } else {
+                            showToast(`导入完成，成功 ${data.success_count} 条，失败 ${data.failed_count} 条`, 'warning');
+                        }
+
+                        if (data.success_count > 0) {
+                            setTimeout(() => location.reload(), 3000);
+                        }
+                    } else if (data.type === 'error') {
+                        showToast(data.error, 'error');
+                    }
+                } catch (e) {
+                    console.error('解析流数据失败:', e, line);
+                }
+            }
+        }
+    } catch (error) {
+        showToast(error.message || '网络错误', 'error');
+    } finally {
+        if (submitButton) {
+            submitButton.disabled = false;
+            submitButton.textContent = '批量导入';
+        }
     }
 }
 
@@ -832,4 +1057,6 @@ async function deleteMember(teamId, userId, email, inModal = false) {
 if (typeof window !== 'undefined') {
     window.generateOAuthAuthorizeLink = generateOAuthAuthorizeLink;
     window.parseOAuthCallbackAndFill = parseOAuthCallbackAndFill;
+    window.exportOAuthJsonTemplateFile = exportOAuthJsonTemplateFile;
+    window.handleJsonFileImport = handleJsonFileImport;
 }

--- a/app/static/js/redeem.js
+++ b/app/static/js/redeem.js
@@ -18,6 +18,7 @@ let currentEmail = '';
 let currentCode = '';
 let availableTeams = [];
 let selectedTeamId = null;
+let currentTopTab = 'redeem';
 
 // Toast提示函数
 function showToast(message, type = 'info') {
@@ -52,11 +53,36 @@ function showStep(stepNumber) {
     }
 }
 
+function switchTopTab(tabName) {
+    currentTopTab = tabName;
+
+    const redeemPanel = document.getElementById('redeemPanel');
+    const warrantyPanel = document.getElementById('warrantyPanel');
+    const tabRedeem = document.getElementById('tabRedeem');
+    const tabWarranty = document.getElementById('tabWarranty');
+
+    if (redeemPanel) redeemPanel.classList.toggle('active', tabName === 'redeem');
+    if (warrantyPanel) warrantyPanel.classList.toggle('active', tabName === 'warranty');
+    if (tabRedeem) tabRedeem.classList.toggle('active', tabName === 'redeem');
+    if (tabWarranty) tabWarranty.classList.toggle('active', tabName === 'warranty');
+}
+
 // 返回步骤1
 function backToStep1() {
     showStep(1);
+    switchTopTab('redeem');
     selectedTeamId = null;
 }
+
+document.addEventListener('DOMContentLoaded', () => {
+    const tabRedeem = document.getElementById('tabRedeem');
+    const tabWarranty = document.getElementById('tabWarranty');
+
+    if (tabRedeem) tabRedeem.addEventListener('click', () => switchTopTab('redeem'));
+    if (tabWarranty) tabWarranty.addEventListener('click', () => switchTopTab('warranty'));
+
+    switchTopTab('redeem');
+});
 
 // 步骤1: 验证兑换码并直接兑换
 document.getElementById('verifyForm').addEventListener('submit', async (e) => {
@@ -328,6 +354,11 @@ async function checkWarranty() {
     }
 
     const checkBtn = document.getElementById('checkWarrantyBtn');
+    const warrantyResultContainer = document.getElementById('warrantyResultContainer');
+    if (warrantyResultContainer) {
+        warrantyResultContainer.style.display = 'none';
+    }
+
     checkBtn.disabled = true;
     checkBtn.innerHTML = '<i data-lucide="loader" class="spinning"></i> 查询中...';
     if (window.lucide) lucide.createIcons();
@@ -540,9 +571,13 @@ function showWarrantyResult(data) {
 
     if (window.lucide) lucide.createIcons();
 
-    // 显示质保结果区域
-    document.querySelectorAll('.step').forEach(step => step.style.display = 'none');
-    document.getElementById('warrantyResult').style.display = 'block';
+    // 在顶部导航下展示质保结果
+    showStep(1);
+    switchTopTab('warranty');
+    const warrantyResultContainer = document.getElementById('warrantyResultContainer');
+    if (warrantyResultContainer) {
+        warrantyResultContainer.style.display = 'block';
+    }
 }
 
 // 复制质保兑换码
@@ -644,19 +679,13 @@ async function enableUserDeviceAuth(teamId, code, email) {
 // 从成功页面跳转到质保查询
 function goToWarrantyFromSuccess() {
     const warrantyInput = document.getElementById('warrantyInput');
-    // 优先填入邮箱，因为邮箱查询更全面
-    warrantyInput.value = currentEmail || currentCode || '';
-
-    // 切换视图
-    document.querySelectorAll('.step').forEach(s => s.classList.remove('active'));
-    document.getElementById('step1').classList.add('active');
-    document.getElementById('step3').style.display = 'none';
-
-    // 滚动到质保区域
-    const warrantySection = document.querySelector('.warranty-section');
-    if (warrantySection) {
-        warrantySection.scrollIntoView({ behavior: 'smooth' });
+    if (warrantyInput) {
+        // 优先填入邮箱，因为邮箱查询更全面
+        warrantyInput.value = currentEmail || currentCode || '';
     }
+
+    showStep(1);
+    switchTopTab('warranty');
 
     // 自动触发查询
     checkWarranty();

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -121,7 +121,8 @@
                             <textarea id="oauthCallbackInput" class="form-control" rows="3" placeholder="登录后把完整回调 URL 粘贴到这里"></textarea>
                             <div style="margin-top: 0.5rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
                                 <button type="button" id="btnParseOAuthCallback" class="btn btn-secondary">解析并自动填充</button>
-                                <small class="form-text" style="margin: 0; align-self: center;">粘贴回调后自动解析并填充 AT / RT / Client ID。</small>
+                                <button type="button" id="btnExportOAuthJson" class="btn btn-secondary">导出 JSON 文件</button>
+                                <small class="form-text" style="margin: 0; align-self: center;">粘贴回调后可自动填充 AT / RT / Client ID，或导出 JSON 模板文件。</small>
                             </div>
                         </div>
                         <div class="form-group">
@@ -162,6 +163,14 @@
 
                 <div id="batchImport" class="import-panel" style="display: none;">
                     <form id="batchImportForm" onsubmit="handleBatchImport(event)">
+                        <div class="form-group" style="padding: 0.75rem; border: 1px dashed var(--border); border-radius: 10px; margin-bottom: 1rem;">
+                            <label style="margin-bottom: 0.5rem; display: block;">JSON 文件导入</label>
+                            <div style="display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center;">
+                                <input type="file" id="jsonImportFile" accept=".json,application/json" class="form-control" style="max-width: 300px;">
+                                <button type="button" class="btn btn-secondary" onclick="handleJsonFileImport()">导入 JSON</button>
+                                <small class="form-text" style="margin: 0;">支持单对象、对象数组，或 {"teams": [...]} 格式。</small>
+                            </div>
+                        </div>
                         <div class="form-group">
                             <label>批量导入内容 <span class="required">*</span></label>
                             <textarea name="batchContent" class="form-control" rows="8" placeholder="一行一个 AT Token..."

--- a/app/templates/user/redeem.html
+++ b/app/templates/user/redeem.html
@@ -11,10 +11,10 @@
 </head>
 
 <body>
-    <div class="container">
-        <div class="header">
-            <h1>GPT Team 兑换</h1>
-            <p class="subtitle">使用兑换码加入 ChatGPT Team</p>
+    <div class="container full-layout">
+        <div class="header full-header">
+            <h1>GPT Team 兑换中心</h1>
+            <p class="subtitle">自助上车与质保查询一体化入口</p>
             {% if remaining_spots is not none %}
             <div class="spots-badge"
                 style="display: inline-flex; align-items: center; gap: 6px; background: var(--primary-soft); padding: 6px 12px; border-radius: 20px; font-size: 0.875rem; color: var(--primary); margin-top: 10px; border: 1px solid var(--border-base);">
@@ -23,34 +23,42 @@
             {% endif %}
         </div>
 
-        <!-- 步骤1: 输入兑换码 -->
+        <div class="top-nav-tabs">
+            <button type="button" id="tabRedeem" class="top-tab active" data-tab="redeem">
+                <i data-lucide="rocket"></i> 自助上车
+            </button>
+            <button type="button" id="tabWarranty" class="top-tab" data-tab="warranty">
+                <i data-lucide="shield"></i> 质保查询
+            </button>
+        </div>
+
+        <!-- 步骤1: 顶部导航切换区域 -->
         <div id="step1" class="step active">
-            <div class="card">
-                <h2>输入兑换信息</h2>
-                <form id="verifyForm">
-                    <div class="form-group">
-                        <label for="email">邮箱地址</label>
-                        <input type="email" id="email" name="email" required placeholder="请输入您的邮箱地址" class="form-input">
-                        <p class="form-help">请填写您要接受邀请的账号的邮箱，邀请将发送到此邮箱</p>
-                    </div>
+            <div id="redeemPanel" class="tab-panel active">
+                <div class="surface-panel">
+                    <h2>输入兑换信息</h2>
+                    <form id="verifyForm">
+                        <div class="form-group">
+                            <label for="email">邮箱地址</label>
+                            <input type="email" id="email" name="email" required placeholder="请输入您的邮箱地址" class="form-input">
+                            <p class="form-help">请填写您要接受邀请的账号的邮箱，邀请将发送到此邮箱</p>
+                        </div>
 
-                    <div class="form-group">
-                        <label for="code">兑换码</label>
-                        <input type="text" id="code" name="code" required placeholder="请输入兑换码" class="form-input">
-                    </div>
+                        <div class="form-group">
+                            <label for="code">兑换码</label>
+                            <input type="text" id="code" name="code" required placeholder="请输入兑换码" class="form-input">
+                        </div>
 
-                    <button type="submit" class="btn btn-primary" id="verifyBtn">
-                        <i data-lucide="shield-check"></i> 验证兑换码
-                    </button>
-                </form>
+                        <button type="submit" class="btn btn-primary" id="verifyBtn">
+                            <i data-lucide="shield-check"></i> 验证兑换码
+                        </button>
+                    </form>
+                </div>
+            </div>
 
-                <!-- 质保查询区域 -->
-                <div class="warranty-section"
-                    style="margin-top: 40px; padding-top: 30px; border-top: 1px solid var(--border-base);">
-                    <h3 style="font-size: 1.1rem; margin-bottom: 15px; color: var(--text-primary);">
-                        <i data-lucide="shield" style="width: 18px; height: 18px; vertical-align: middle;"></i>
-                        质保查询
-                    </h3>
+            <div id="warrantyPanel" class="tab-panel">
+                <div class="surface-panel">
+                    <h2>质保查询</h2>
                     <p class="form-help" style="margin-bottom: 15px;">
                         如果您使用质保兑换码加入的 Team 被封号，可以在质保期内（一个月）重复使用原兑换码
                     </p>
@@ -61,26 +69,17 @@
                         style="width: 100%;">
                         <i data-lucide="search"></i> 查询质保状态
                     </button>
-                </div>
-            </div>
-        </div>
 
-        <!-- 质保查询结果 -->
-        <div id="warrantyResult" class="step" style="display: none;">
-            <div class="card">
-                <h2>质保查询结果</h2>
-                <div id="warrantyContent">
-                    <!-- 质保结果将通过JavaScript动态生成 -->
-                </div>
-                <div class="actions" style="margin-top: 20px;">
-                    <button onclick="backToStep1()" class="btn btn-secondary">返回</button>
+                    <div id="warrantyResultContainer" style="display: none; margin-top: 24px;">
+                        <div id="warrantyContent"></div>
+                    </div>
                 </div>
             </div>
         </div>
 
         <!-- 步骤2: 选择Team (已废弃，保留占位符防止 JS 报错) -->
         <div id="step2" class="step" style="display: none;">
-            <div class="card">
+            <div class="surface-panel">
                 <h2>选择 Team</h2>
                 <div id="teamsList" class="teams-list"></div>
                 <div class="actions">
@@ -92,7 +91,7 @@
 
         <!-- 步骤3: 兑换结果 -->
         <div id="step3" class="step">
-            <div class="card">
+            <div class="surface-panel">
                 <div id="resultContent">
                     <!-- 结果内容将通过JavaScript动态生成 -->
                 </div>


### PR DESCRIPTION
### Motivation

- Provide a JSON-based bulk Team import option in addition to the existing line-based batch import and make it stream progress back to the client. 
- Allow exporting a parsed OAuth callback into a JSON template for easier offline/team imports and improve client-side parsing and UX for OAuth/token flows. 
- Refresh the user-facing redeem page and admin UI pieces with improved styling, top-tab navigation, and clearer progress/status UI for imports.

### Description

- Backend: added `import_team_json` to `app/services/team.py` which accepts JSON text, normalizes multiple formats (`array`, single object, or `{"teams": [...]}`), and yields NDJSON progress events; `app/routes/admin.py` now handles `import_type == "json"` and returns a `StreamingResponse` that streams the import progress. 
- Frontend: enhanced `app/static/js/main.js` with `parseOAuthCallbackData`, `buildOAuthJsonTemplate`, `exportOAuthJsonTemplateFile`, and `handleJsonFileImport` to support export of OAuth JSON templates, parsing callback data, uploading a JSON file to the new JSON import endpoint, and incremental UI updates based on streamed NDJSON responses. 
- UI/CSS/Templates: major cosmetic and layout updates in `app/static/css/user.css` (theme variables, responsive layout, top tabs, surface panels), template updates in `app/templates/base.html` (JSON import file input, export button) and `app/templates/user/redeem.html` (top navigation tabs, consolidated surface panels), and JS in `app/static/js/redeem.js` to support top-tab switching and refined warranty result flows.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b3d74d5c58832f862cbf42d35f4f1c)