### PR TITLE
feat(ui): refresh redeem page and add dark admin console theme

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -65,6 +65,108 @@ body {
     min-height: 100vh;
 }
 
+
+/* Admin dark style (inspired by redeem page) */
+body.admin-theme {
+    --primary: #4f8ef7;
+    --primary-hover: #3d7fe9;
+    --primary-soft: rgba(79, 142, 247, 0.16);
+    --bg-main: #060c1f;
+    --bg-surface: rgba(10, 20, 45, 0.86);
+    --text-main: #e8edf7;
+    --text-muted: #95a6bf;
+    --text-dim: #6f8098;
+    --border-base: rgba(148, 163, 184, 0.24);
+    --success-soft: rgba(16, 185, 129, 0.18);
+    --warning-soft: rgba(245, 158, 11, 0.18);
+    --danger-soft: rgba(239, 68, 68, 0.18);
+    background: radial-gradient(130% 120% at 0% 0%, #111b3a 0%, #060c1f 52%, #040714 100%);
+    color: var(--text-main);
+}
+
+body.admin-theme::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background-image:
+        linear-gradient(rgba(79, 142, 247, 0.04) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(79, 142, 247, 0.04) 1px, transparent 1px);
+    background-size: 48px 48px;
+    mask-image: radial-gradient(circle at center, rgba(0, 0, 0, 0.72), transparent 90%);
+    z-index: 0;
+}
+
+body.admin-theme .navbar,
+body.admin-theme .sidebar,
+body.admin-theme .footer,
+body.admin-theme .main-content,
+body.admin-theme .table-container,
+body.admin-theme .content-section,
+body.admin-theme .card,
+body.admin-theme .modal,
+body.admin-theme .dropdown-menu,
+body.admin-theme .input-group-clean,
+body.admin-theme .form-control,
+body.admin-theme .form-control-sm,
+body.admin-theme .btn-secondary {
+    background-color: var(--bg-surface);
+    border-color: var(--border-base);
+}
+
+body.admin-theme .navbar,
+body.admin-theme .sidebar,
+body.admin-theme .footer {
+    backdrop-filter: blur(14px);
+}
+
+body.admin-theme .main-container,
+body.admin-theme .main-content,
+body.admin-theme .content-section,
+body.admin-theme .table-container,
+body.admin-theme .modal,
+body.admin-theme .dropdown-menu,
+body.admin-theme .footer,
+body.admin-theme .page-header {
+    position: relative;
+    z-index: 1;
+}
+
+body.admin-theme .menu-item a:hover,
+body.admin-theme .data-table tbody tr:hover td,
+body.admin-theme .dropdown-item:hover {
+    background: rgba(79, 142, 247, 0.12);
+}
+
+body.admin-theme .menu-item.active a {
+    background: linear-gradient(135deg, rgba(79, 142, 247, 0.28), rgba(123, 94, 167, 0.28));
+    color: #eaf1ff;
+    box-shadow: inset 0 0 0 1px rgba(79, 142, 247, 0.35);
+}
+
+body.admin-theme .btn-primary {
+    background: linear-gradient(135deg, #4f8ef7, #7b5ea7);
+    border-color: transparent;
+}
+
+body.admin-theme .btn-primary:hover {
+    background: linear-gradient(135deg, #5896fb, #8667b5);
+}
+
+body.admin-theme .stat-card,
+body.admin-theme .status-badge.status-banned {
+    background: rgba(255, 255, 255, 0.02);
+    border-color: var(--border-base);
+}
+
+body.admin-theme .status-badge.status-banned {
+    color: #cbd5e1;
+}
+
+body.admin-theme .data-table th {
+    background: rgba(10, 20, 45, 0.98);
+}
+
 /* Animations */
 @keyframes fadeInUp {
     from {

--- a/app/static/css/user.css
+++ b/app/static/css/user.css
@@ -185,6 +185,84 @@ body {
   box-shadow: inset 0 0 0 1px rgba(79, 142, 247, 0.32);
 }
 
+.top-nav-tabs {
+  position: relative;
+  overflow: hidden;
+}
+
+.tab-indicator {
+  position: absolute;
+  top: 6px;
+  bottom: 6px;
+  left: 6px;
+  width: calc(50% - 10px);
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(79, 142, 247, 0.28), rgba(123, 94, 167, 0.28));
+  box-shadow: inset 0 0 0 1px rgba(79, 142, 247, 0.32), 0 0 24px rgba(79, 142, 247, 0.15);
+  transition: left .3s cubic-bezier(0.4, 0, 0.2, 1), width .3s cubic-bezier(0.4, 0, 0.2, 1);
+  z-index: 0;
+}
+
+.top-tab {
+  position: relative;
+  z-index: 1;
+}
+
+.top-tab.active {
+  background: transparent;
+  box-shadow: none;
+}
+
+.info-box,
+.warning-box {
+  margin-top: 18px;
+  border-radius: 12px;
+  padding: 13px 14px;
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.info-box {
+  border: 1px solid rgba(79, 142, 247, 0.28);
+  background: rgba(79, 142, 247, 0.1);
+  color: #c2dafe;
+}
+
+.info-box .info-icon {
+  width: 16px;
+  height: 16px;
+  margin-top: 2px;
+  color: #8ab5ff;
+  flex-shrink: 0;
+}
+
+.warning-box {
+  margin-top: 16px;
+  border: 1px solid rgba(245, 158, 11, 0.3);
+  background: rgba(245, 158, 11, 0.1);
+  color: #facc74;
+}
+
+.warning-box i {
+  width: 16px;
+  height: 16px;
+  margin-top: 2px;
+  flex-shrink: 0;
+}
+
+.required-star {
+  color: #fb7185;
+}
+
+.field-hint {
+  margin-top: 7px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
 .step { display: none; margin-top: 14px; }
 .step.active { display: block; }
 

--- a/app/static/js/redeem.js
+++ b/app/static/js/redeem.js
@@ -53,6 +53,14 @@ function showStep(stepNumber) {
     }
 }
 
+function updateTabIndicator(activeTab) {
+    const indicator = document.getElementById('tabIndicator');
+    if (!indicator || !activeTab) return;
+
+    indicator.style.left = `${activeTab.offsetLeft}px`;
+    indicator.style.width = `${activeTab.offsetWidth}px`;
+}
+
 function switchTopTab(tabName) {
     currentTopTab = tabName;
 
@@ -65,6 +73,8 @@ function switchTopTab(tabName) {
     if (warrantyPanel) warrantyPanel.classList.toggle('active', tabName === 'warranty');
     if (tabRedeem) tabRedeem.classList.toggle('active', tabName === 'redeem');
     if (tabWarranty) tabWarranty.classList.toggle('active', tabName === 'warranty');
+
+    updateTabIndicator(tabName === 'redeem' ? tabRedeem : tabWarranty);
 }
 
 // 返回步骤1
@@ -82,6 +92,10 @@ document.addEventListener('DOMContentLoaded', () => {
     if (tabWarranty) tabWarranty.addEventListener('click', () => switchTopTab('warranty'));
 
     switchTopTab('redeem');
+    window.addEventListener('resize', () => {
+        const activeTab = document.querySelector('.top-tab.active');
+        updateTabIndicator(activeTab);
+    });
 });
 
 // 步骤1: 验证兑换码并直接兑换
@@ -104,14 +118,16 @@ document.getElementById('verifyForm').addEventListener('submit', async (e) => {
 
     // 禁用按钮
     verifyBtn.disabled = true;
-    verifyBtn.textContent = '正在兑换...';
+    verifyBtn.innerHTML = '<i data-lucide="loader-circle" class="spinning"></i> 正在兑换...';
+    if (window.lucide) lucide.createIcons();
 
     // 直接调用兑换接口 (team_id = null 表示自动选择)
     await confirmRedeem(null);
 
     // 恢复按钮状态 (如果 confirmRedeem 失败并显示了错误也没关系，因为用户可以点返回重试)
     verifyBtn.disabled = false;
-    verifyBtn.textContent = '验证兑换码';
+    verifyBtn.innerHTML = '<i data-lucide="shield-check"></i> 验证并激活兑换码';
+    if (window.lucide) lucide.createIcons();
 });
 
 // 渲染Team列表

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -12,7 +12,7 @@
     {% block extra_css %}{% endblock %}
 </head>
 
-<body class="bg-gray-50 text-slate-900">
+<body class="bg-gray-50 text-slate-900{% if user %} admin-theme{% endif %}">
     {% if user %}
     <!-- 导航栏 -->
     <nav class="navbar">

--- a/app/templates/user/redeem.html
+++ b/app/templates/user/redeem.html
@@ -36,6 +36,7 @@
 
             <section class="main-shell">
                 <nav class="top-nav-tabs">
+                    <div class="tab-indicator" id="tabIndicator" aria-hidden="true"></div>
                     <button type="button" id="tabRedeem" class="top-tab active" data-tab="redeem">
                         <i data-lucide="gift"></i> 自助上车
                     </button>
@@ -51,25 +52,32 @@
                             <p>填写邮箱与兑换码后，系统将自动分配可用 Team 并发送邀请。</p>
                         </div>
 
+                        <div class="info-box">
+                            <i data-lucide="info" class="info-icon"></i>
+                            <p>请确保填写 <strong>ChatGPT 注册邮箱</strong>，兑换成功后绑定账号无法变更。</p>
+                        </div>
+
                         <form id="verifyForm" class="stack-form">
                             <div class="form-group">
-                                <label for="email">邮箱地址</label>
+                                <label for="email">邮箱地址 <span class="required-star">*</span></label>
                                 <div class="field-wrap">
                                     <i data-lucide="mail" class="field-icon"></i>
                                     <input type="email" id="email" name="email" required placeholder="your@email.com" class="form-input">
                                 </div>
+                                <p class="field-hint">邀请邮件将发送到该地址，请确认可正常接收。</p>
                             </div>
 
                             <div class="form-group">
-                                <label for="code">兑换码</label>
+                                <label for="code">兑换码 <span class="required-star">*</span></label>
                                 <div class="field-wrap">
                                     <i data-lucide="key-round" class="field-icon"></i>
-                                    <input type="text" id="code" name="code" required placeholder="请输入兑换码" class="form-input">
+                                    <input type="text" id="code" name="code" required placeholder="XXXX-XXXX-XXXX-XXXX" class="form-input">
                                 </div>
+                                <p class="field-hint">兑换码区分大小写，请复制粘贴避免输错。</p>
                             </div>
 
                             <button type="submit" class="btn btn-primary" id="verifyBtn">
-                                <i data-lucide="shield-check"></i> 验证兑换码
+                                <i data-lucide="shield-check"></i> 验证并激活兑换码
                             </button>
                         </form>
                     </section>
@@ -78,6 +86,11 @@
                         <div class="panel-head">
                             <h2>质保查询</h2>
                             <p>若您加入的 Team 失效，可在质保期内查询并自助处理。</p>
+                        </div>
+
+                        <div class="info-box">
+                            <i data-lucide="clipboard-check" class="info-icon"></i>
+                            <p>质保期为 <strong>一个月</strong>，在有效期内可用原兑换码重新加入 Team。</p>
                         </div>
 
                         <div class="warranty-query-row">
@@ -92,6 +105,11 @@
 
                         <div id="warrantyResultContainer" class="warranty-result-container" style="display: none;">
                             <div id="warrantyContent"></div>
+                        </div>
+
+                        <div class="warning-box">
+                            <i data-lucide="alert-triangle"></i>
+                            <p>质保仅限账号封禁或 Team 异常，不包含主动退出 Team 的情况。</p>
                         </div>
                     </section>
                 </div>


### PR DESCRIPTION
### Motivation
- Improve the user experience of the invite/兑换 (redeem) flow with clearer UI, guidance and visual feedback. 
- Bring the admin console into the same dark "tech" aesthetic so the product has a consistent look & feel.

### Description
- Updated the redeem page structure and copy to add guidance and stronger affordances, including a sliding tab indicator, `info-box` and `warning-box` callouts, required-field marker and hints, and a clearer placeholder format for codes (`XXXX-XXXX-XXXX-XXXX`), implemented in `app/templates/user/redeem.html` and `app/static/css/user.css`.
- Enhanced client behavior: added a loading icon and restored icon+label after submit, and added logic to animate/resize the tab indicator on tab switch and window resize, implemented in `app/static/js/redeem.js`.
- Unified admin visuals: add an `admin-theme` class to the logged-in base template and a dark, grid/gradient admin skin with targeted overrides for navbar, sidebar, cards, tables and buttons in `app/templates/base.html` and `app/static/css/style.css`.
- Kept existing layout and server behavior unchanged; changes are purely visual and client-side interaction improvements. Files modified: `app/templates/user/redeem.html`, `app/static/css/user.css`, `app/static/js/redeem.js`, `app/templates/base.html`, `app/static/css/style.css`.

### Testing
- Compiled Python sources with `python -m compileall app` (succeeded).
- Ran unit tests with `pytest -q` (1 test skipped; overall suite passed).
- Launched the app locally with `python -m uvicorn app.main:app` and exercised pages; captured screenshots of the updated redeem page and admin dashboard via Playwright to verify visuals and interactive tab indicator (screenshots generated successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b4267ed904832fa7466d6510594902)