### PR TITLE
docs: update clone URL and add overwrite-old-project deployment steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 ### 一键部署
 ```bash
-git clone https://github.com/tibbar213/team-manage.git
-cd team-manage
+git clone https://github.com/loLollipop/team-manage-refresh.git
+cd team-manage-refresh
 cp .env.example .env
 docker compose up -d
 ```
@@ -15,6 +15,14 @@ docker compose up -d
 ### 一键更新
 ```bash
 git pull && docker compose down && docker compose up -d --build
+```
+
+### 覆盖旧项目（重写历史/强推后推荐）
+```bash
+git fetch origin
+git checkout main
+git reset --hard origin/main
+docker compose down && docker compose up -d --build
 ```
 
 ## ✨ 功能特性
@@ -106,8 +114,8 @@ git pull && docker compose down && docker compose up -d --build
 ### 1. 克隆项目
 
 ```bash
-git clone https://github.com/tibbar213/team-manage.git
-cd team-manage
+git clone https://github.com/loLollipop/team-manage-refresh.git
+cd team-manage-refresh
 ```
 
 ### 2. 创建虚拟环境


### PR DESCRIPTION
### Motivation
- 将 README 中的一键部署与快速开始的仓库地址替换为新的仓库以保持说明一致性和可用性。 
- 提供一个针对“重写历史/强推后”场景的显式覆盖流程，方便在需要强制同步远端主分支时快速恢复部署。 

### Description
- 将一键部署与快速开始的克隆地址更改为 `https://github.com/loLollipop/team-manage-refresh.git` 并同步目录为 `team-manage-refresh`。 
- 新增章节 `### 覆盖旧项目（重写历史/强推后推荐）`，包含 `git fetch origin`、`git checkout main`、`git reset --hard origin/main` 和 `docker compose down && docker compose up -d --build` 四条命令示例。 
- 变更仅限于 `README.md` 的文档更新，没有修改运行时代码或配置文件。 

### Testing
- 使用 `git diff -- README.md` 验证了 README 的差异，确认新 URL 和新增章节已正确插入。 
- 使用 `nl -ba README.md` 检查文件内容，确认一键部署与快速开始段落以及新增覆盖步骤均显示如预期。 
- 变更为文档类修改，无自动化单元/集成测试需要执行。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b637477fac832fb78f1842099e283d)