### PR TITLE
feat(admin): 提升 Team 最大成员数输入上限至 999

### DIFF
--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -409,7 +409,7 @@
                 <div class="form-group">
                     <label>最大成员数 <span class="required">*</span></label>
                     <input type="number" id="edit-team-max-members" name="maxMembers" class="form-control" min="1"
-                        max="100" required>
+                        max="999" required>
                 </div>
                 <div class="form-group">
                     <label>状态 <span class="required">*</span></label>


### PR DESCRIPTION
### Motivation
- 将后台 Team 编辑弹窗中 `max_members` 的前端输入上限从 `100` 放宽到 `999`，以支持将 team 席位上限设置为 999。

### Description
- 修改模板文件 `app/templates/admin/index.html` 中 `#edit-team-max-members` 输入框的 `max` 属性由 `100` 更新为 `999`。

### Testing
- 使用 `rg -n "edit-team-max-members|max=\"999\"" app/templates/admin/index.html` 验证模板已更新（通过）。
- 启动应用 `python -m uvicorn app.main:app --host 0.0.0.0 --port 8008` 并使用浏览器自动化脚本打开 `/admin/` 页面生成截图以验证页面可正常加载（通过）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b69444c080832fbee7a3ff544a866a)