### PR TITLE
Align welfare code capacity to current available seats and increase team size limit

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -201,10 +201,11 @@ async def welfare_dashboard(
         welfare_limit_raw = await settings_service.get_setting(db, "welfare_common_code_limit", "0")
         welfare_used_raw = await settings_service.get_setting(db, "welfare_common_code_used_count", "0")
 
-        # 福利通用码的可用次数应按“可邀请席位”计算：sum(max_members - 1)
-        usable_capacity_stmt = select(func.sum(Team.max_members - 1)).where(
+        # 福利通用码可用次数应与当前可用车位一致：sum(max_members - current_members)
+        usable_capacity_stmt = select(func.sum(Team.max_members - Team.current_members)).where(
             Team.pool_type == "welfare",
-            Team.max_members > 1
+            Team.status == "active",
+            Team.current_members < Team.max_members
         )
         usable_capacity_result = await db.execute(usable_capacity_stmt)
         usable_capacity = int(usable_capacity_result.scalar() or 0)
@@ -218,7 +219,7 @@ async def welfare_dashboard(
         except Exception:
             welfare_used = 0
 
-        # 兼容历史错误值：展示时按真实可邀请席位收敛
+        # 兼容历史错误值：展示时按当前真实可用车位收敛
         effective_limit = usable_capacity if usable_capacity >= 0 else 0
 
         stats = {
@@ -261,9 +262,10 @@ async def generate_welfare_common_code(
 ):
     """生成/更新福利通用兑换码（不落库到 redemption_codes，仅存 settings）。"""
     try:
-        seats_stmt = select(func.sum(Team.max_members - 1)).where(
+        seats_stmt = select(func.sum(Team.max_members - Team.current_members)).where(
             Team.pool_type == "welfare",
-            Team.max_members > 1
+            Team.status == "active",
+            Team.current_members < Team.max_members
         )
         seats_result = await db.execute(seats_stmt)
         total_seats = int(seats_result.scalar() or 0)

--- a/app/services/redemption.py
+++ b/app/services/redemption.py
@@ -274,15 +274,16 @@ class RedemptionService:
                     except Exception:
                         used_count = 0
 
-                    # 真实可兑换次数按可邀请席位计算：sum(max_members - 1)
-                    capacity_stmt = select(func.sum(Team.max_members - 1)).where(
+                    # 真实可兑换次数按当前可用车位计算：sum(max_members - current_members)
+                    capacity_stmt = select(func.sum(Team.max_members - Team.current_members)).where(
                         Team.pool_type == "welfare",
-                        Team.max_members > 1
+                        Team.status == "active",
+                        Team.current_members < Team.max_members
                     )
                     capacity_result = await db_session.execute(capacity_stmt)
                     usable_capacity = int(capacity_result.scalar() or 0)
 
-                    # 兼容历史错误配置：向下收敛到真实可邀请席位
+                    # 兼容历史错误配置：向下收敛到当前真实可用车位
                     effective_limit = min(limit_count, usable_capacity) if limit_count > 0 else usable_capacity
 
                     if effective_limit <= 0 or used_count >= effective_limit:

--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -409,7 +409,7 @@
                 <div class="form-group">
                     <label>最大成员数 <span class="required">*</span></label>
                     <input type="number" id="edit-team-max-members" name="maxMembers" class="form-control" min="1"
-                        max="100" required>
+                        max="999" required>
                 </div>
                 <div class="form-group">
                     <label>状态 <span class="required">*</span></label>


### PR DESCRIPTION
### Motivation
- Ensure welfare common-code usable count reflects real available seats by counting `max_members - current_members` rather than `max_members - 1`.
- Only count teams that are currently `active` and have available seats to avoid over-allocating code capacity.
- Allow larger team sizes in the admin UI by raising the `max` for `maxMembers` input to `999`.

### Description
- Updated the capacity calculation in the welfare admin dashboard (`usable_capacity_stmt`) to use `Team.max_members - Team.current_members` and to filter with `Team.status == "active"` and `Team.current_members < Team.max_members`.
- Updated the generation endpoint (`/welfare/code/generate`) to compute `total_seats` using `Team.max_members - Team.current_members` with the same active/available filters and store that value in settings when creating a new welfare code.
- Updated the redemption validation in `RedemptionService` to compute virtual welfare code capacity with `Team.max_members - Team.current_members`, and to converge `effective_limit` to the current usable capacity.
- Increased the admin team edit template `maxMembers` input `max` attribute from `100` to `999` and applied minor template newline fix.

### Testing
- Ran the automated unit test suite with `pytest`, including tests touching redemption and admin team logic, and the suite completed successfully.
- Executed integration tests for welfare code generation and redemption flows, and they passed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b69444c080832fbee7a3ff544a866a)