### PR TITLE
Propagate API error metadata and simplify DB commit handling in Team and ChatGPT services

### DIFF
--- a/app/services/chatgpt.py
+++ b/app/services/chatgpt.py
@@ -202,7 +202,14 @@ class ChatGPTService:
             headers = {"Authorization": f"Bearer {access_token}"}
             result = await self._make_request("GET", url, headers, db_session=db_session, identifier=identifier)
             if not result["success"]:
-                return {"success": False, "members": [], "total": 0, "error": result["error"]}
+                return {
+                    "success": False,
+                    "members": [],
+                    "total": 0,
+                    "error": result["error"],
+                    "error_code": result.get("error_code"),
+                    "status_code": result.get("status_code"),
+                }
             data = result["data"]
             items = data.get("items", [])
             total = data.get("total", 0)
@@ -227,7 +234,14 @@ class ChatGPTService:
         }
         result = await self._make_request("GET", url, headers, db_session=db_session, identifier=identifier)
         if not result["success"]:
-            return {"success": False, "items": [], "total": 0, "error": result["error"]}
+            return {
+                "success": False,
+                "items": [],
+                "total": 0,
+                "error": result["error"],
+                "error_code": result.get("error_code"),
+                "status_code": result.get("status_code"),
+            }
         data = result["data"]
         items = data.get("items", [])
         return {"success": True, "items": items, "total": len(items), "error": None}
@@ -299,7 +313,13 @@ class ChatGPTService:
         headers = {"Authorization": f"Bearer {access_token}"}
         result = await self._make_request("GET", url, headers, db_session=db_session, identifier=identifier)
         if not result["success"]:
-            return {"success": False, "accounts": [], "error": result["error"]}
+            return {
+                "success": False,
+                "accounts": [],
+                "error": result["error"],
+                "error_code": result.get("error_code"),
+                "status_code": result.get("status_code"),
+            }
         
         data = result["data"]
         accounts_data = data.get("accounts", {})

--- a/app/services/team.py
+++ b/app/services/team.py
@@ -81,8 +81,7 @@ class TeamService:
         if error_code == "ghost_success":
             logger.error(f"检测到 Team {team.id} ({team.email}) 存在“虚假成功”现象 (邀请返回 200 但列表无成员)，标记为 error")
             team.status = "error"
-            if not db_session.in_transaction():
-                await db_session.commit()
+            await db_session.commit()
             return True
 
         if is_banned:
@@ -96,8 +95,7 @@ class TeamService:
                 
             logger.warning(f"检测到账号{status_desc} (code={error_code}, msg={error_msg}), 更新 Team {team.id} ({team.email}) 状态为 banned")
             team.status = "banned"
-            if not db_session.in_transaction():
-                await db_session.commit()
+            await db_session.commit()
             return True
 
         # 2. 判定是否为“席位已满”错误
@@ -113,8 +111,7 @@ class TeamService:
                 # 进位修正，确保逻辑闭环
                 team.current_members = team.max_members
 
-            if not db_session.in_transaction():
-                await db_session.commit()
+            await db_session.commit()
             return True
 
         # 2.5 判定是否为“已在团队中” (这通常被视为成功的变种)
@@ -147,8 +144,7 @@ class TeamService:
             # 注意：此处不等待刷新结果，仅作为修复尝试
             await self.ensure_access_token(team, db_session)
             
-        if not db_session.in_transaction():
-            await db_session.commit()
+        await db_session.commit()
         return True
         
     async def _reset_error_status(self, team: Team, db_session: AsyncSession) -> None:
@@ -167,8 +163,7 @@ class TeamService:
             else:
                 logger.info(f"Team {team.id} ({team.email}) 请求成功, 将状态从 error 恢复为 active")
                 team.status = "active"
-        if not db_session.in_transaction():
-            await db_session.commit()
+        await db_session.commit()
 
     async def ensure_access_token(self, team: Team, db_session: AsyncSession, force_refresh: bool = False) -> Optional[str]:
         """
@@ -269,8 +264,7 @@ class TeamService:
             logger.error(f"Team {team.id} Token 已过期且无法刷新，标记为 expired")
             team.status = "expired"
             team.error_count = (team.error_count or 0) + 1
-        if not db_session.in_transaction():
-            await db_session.commit()
+        await db_session.commit()
         return None
 
     async def proactive_refresh_tokens(
@@ -1270,10 +1264,7 @@ class TeamService:
             team.error_count = 0  # 同步成功，重置错误次数
             team.last_sync = get_now()
 
-            if not db_session.in_transaction():
-                await db_session.commit()
-            else:
-                await db_session.flush()
+            await db_session.commit()
 
             logger.info(f"Team 同步成功: ID {team_id}, 成员数 {current_members}")
 


### PR DESCRIPTION
### Motivation
- Return richer error context from ChatGPT HTTP calls so callers can inspect `error_code` and HTTP `status_code` for better error handling and logging.
- Simplify and unify database persistence behavior in `TeamService` by removing conditional `in_transaction()` checks to ensure state changes are reliably committed.

### Description
- Added `error_code` and `status_code` to failure return payloads in `get_members`, `get_invites`, and `get_account_info` in `app/services/chatgpt.py` so callers receive more detailed API error metadata.
- Replaced conditional commits (`if not db_session.in_transaction(): await db_session.commit()`) with unconditional `await db_session.commit()` in multiple places in `app/services/team.py` including `_handle_api_error`, `_reset_error_status`, `ensure_access_token`, and sync completion paths to guarantee persistence of status and token changes.
- Removed the conditional `commit`/`flush` branch in the team sync flow and now always `await db_session.commit()` after updating team fields.
- Kept existing error counting, status transitions, token refresh attempts, and logging behavior while ensuring changes are persisted immediately.

### Testing
- Ran the project's unit test suite with `pytest -q` including service tests for `TeamService` and `ChatGPTService`, and the test run completed without failures.
- Verified relevant service tests exercised error-return paths and token refresh flows and all assertions passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b789ed9d30832f9e166fd95bcf7cd6)