### PR TITLE
Parse expirations in system timezone, safer token refresh fallback, and add Team OAuth token-renew UI

### DIFF
--- a/app/services/team.py
+++ b/app/services/team.py
@@ -7,6 +7,7 @@ import json
 import asyncio
 from typing import Optional, Dict, Any, List
 from datetime import datetime, timedelta
+import pytz
 from sqlalchemy import select, update, delete, func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -17,6 +18,7 @@ from app.services.encryption import encryption_service
 from app.utils.token_parser import TokenParser
 from app.utils.jwt_parser import JWTParser
 from app.utils.time_utils import get_now
+from app.config import settings
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +34,22 @@ class TeamService:
         self.chatgpt_service = chatgpt_service
         self.token_parser = TokenParser()
         self.jwt_parser = JWTParser()
+
+    def _parse_remote_expires_at(self, expires_at_raw: Optional[str]) -> Optional[datetime]:
+        """将 OpenAI 返回的 expires_at 解析为本地时区语义的 naive datetime。"""
+        if not expires_at_raw:
+            return None
+
+        try:
+            normalized = str(expires_at_raw).strip().replace("Z", "+00:00")
+            dt = datetime.fromisoformat(normalized)
+            if dt.tzinfo is not None:
+                local_tz = pytz.timezone(settings.timezone)
+                return dt.astimezone(local_tz).replace(tzinfo=None)
+            return dt
+        except Exception as e:
+            logger.warning(f"解析过期时间失败: {e}")
+            return None
 
     async def _handle_api_error(self, result: Dict[str, Any], team: Team, db_session: AsyncSession) -> bool:
         """
@@ -160,7 +178,7 @@ class TeamService:
             if team.current_members >= team.max_members:
                 logger.info(f"Team {team.id} ({team.email}) 请求成功, 将状态从 error 恢复为 full")
                 team.status = "full"
-            elif team.expires_at and team.expires_at < datetime.now():
+            elif team.expires_at and team.expires_at < get_now():
                 logger.info(f"Team {team.id} ({team.email}) 请求成功, 将状态从 error 恢复为 expired")
                 team.status = "expired"
             else:
@@ -180,12 +198,16 @@ class TeamService:
         Returns:
             有效的 AT Token, 刷新失败返回 None
         """
+        current_valid_token: Optional[str] = None
+
         try:
             # 1. 解密当前 Token
             access_token = encryption_service.decrypt_token(team.access_token_encrypted)
+            if access_token and not self.jwt_parser.is_token_expired(access_token):
+                current_valid_token = access_token
             
             # 2. 检查是否过期 (如果不强制刷新且未过期，则返回)
-            if not force_refresh and not self.jwt_parser.is_token_expired(access_token):
+            if not force_refresh and current_valid_token:
                 return access_token
                 
             if force_refresh:
@@ -262,6 +284,14 @@ class TeamService:
                 # 检查是否为致命错误 (如 token_invalidated)
                 if await self._handle_api_error(refresh_result, team, db_session):
                     return None
+
+        # force_refresh 场景下，如果刷新链路失败但当前 AT 仍可用，则回退到当前 AT，
+        # 避免“误判过期”导致状态被错误写成 expired。
+        if force_refresh and current_valid_token:
+            logger.warning(
+                f"Team {team.id} 强制刷新失败，但现有 AT 仍有效，回退使用当前 Token"
+            )
+            return current_valid_token
 
         if team.status != "banned":
             logger.error(f"Team {team.id} Token 已过期且无法刷新，标记为 expired")
@@ -526,15 +556,7 @@ class TeamService:
                     current_members += invites_result["total"]
 
                 # 解析过期时间
-                expires_at = None
-                if selected_account["expires_at"]:
-                    try:
-                        # ISO 8601 格式: 2026-02-21T23:10:05+00:00
-                        expires_at = datetime.fromisoformat(
-                            selected_account["expires_at"].replace("+00:00", "")
-                        )
-                    except Exception as e:
-                        logger.warning(f"解析过期时间失败: {e}")
+                expires_at = self._parse_remote_expires_at(selected_account.get("expires_at"))
 
                 # 获取账户设置 (包含 beta_settings)
                 device_code_auth_enabled = False
@@ -567,7 +589,7 @@ class TeamService:
                 status = "active"
                 if current_members >= max_members:
                     status = "full"
-                elif expires_at and expires_at < datetime.now():
+                elif expires_at and expires_at < get_now():
                     status = "expired"
 
                 # 加密 AT Token
@@ -748,7 +770,7 @@ class TeamService:
             if team.status in ["active", "full", "expired"]:
                 if team.current_members >= team.max_members:
                     team.status = "full"
-                elif team.expires_at and team.expires_at < datetime.now():
+                elif team.expires_at and team.expires_at < get_now():
                     team.status = "expired"
                 else:
                     team.status = "active"
@@ -1231,14 +1253,7 @@ class TeamService:
                 }
 
             # 6. 解析过期时间
-            expires_at = None
-            if current_account["expires_at"]:
-                try:
-                    expires_at = datetime.fromisoformat(
-                        current_account["expires_at"].replace("+00:00", "")
-                    )
-                except Exception as e:
-                    logger.warning(f"解析过期时间失败: {e}")
+            expires_at = self._parse_remote_expires_at(current_account.get("expires_at"))
 
             # 7.5 获取账户设置 (包含 beta_settings)
             settings_result = await self.chatgpt_service.get_account_settings(
@@ -1256,7 +1271,7 @@ class TeamService:
             status = "active"
             if current_members >= team.max_members:
                 status = "full"
-            elif expires_at and expires_at < datetime.now():
+            elif expires_at and expires_at < get_now():
                 status = "expired"
             
             # 8. 更新 Team 信息

--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -364,6 +364,27 @@
         <div class="modal-body">
             <form id="editTeamForm" onsubmit="handleEditTeam(event)">
                 <input type="hidden" id="edit-team-id" name="teamId">
+                <div class="form-group" style="margin-bottom: 0.9rem;">
+                    <button type="button" class="btn btn-primary" onclick="toggleEditTokenRenewSection()">
+                        <i data-lucide="key-round" style="width: 14px; height: 14px;"></i> 更新 Token（OAuth 回调）
+                    </button>
+                </div>
+                <div id="editTeamTokenRenewSection" class="import-mode-card oauth-quick-card" style="display: none; margin-bottom: 1rem;">
+                    <div class="oauth-quick-head">
+                        <label>更新过期 Team 的 Token</label>
+                        <p class="oauth-quick-subtitle">流程同导入 Team：获取授权链接 → 粘贴回调 → 替换现有 Token。</p>
+                    </div>
+                    <div class="oauth-quick-action-row">
+                        <button type="button" class="btn btn-primary oauth-main-btn" onclick="generateEditOAuthAuthorizeLink()">获取授权链接</button>
+                    </div>
+                    <div class="oauth-quick-fields">
+                        <input type="text" id="editOAuthAuthorizeUrlOutput" class="form-control" placeholder="授权链接会自动复制，这里仅作备份显示" readonly>
+                        <textarea id="editOAuthCallbackInput" class="form-control" rows="3" placeholder="登录后粘贴完整回调 URL"></textarea>
+                    </div>
+                    <div class="oauth-quick-btn-row">
+                        <button type="button" class="btn btn-primary" onclick="parseEditOAuthCallbackAndFill()">解析并替换 Team 信息</button>
+                    </div>
+                </div>
                 <div class="form-group">
                     <label>邮箱 <span class="required">*</span></label>
                     <input type="email" id="edit-team-email" name="email" class="form-control" required>
@@ -502,7 +523,7 @@
 
         try {
             showToast('正在刷新...', 'info');
-            const response = await fetch(`/api/teams/${teamId}/refresh?force=true`, {
+            const response = await fetch(`/api/teams/${teamId}/refresh`, {
                 method: 'GET'
             });
 
@@ -608,12 +629,149 @@
                 document.getElementById('edit-team-status').value = team.status || 'active';
                 document.getElementById('edit-team-role').value = team.account_role || '未知';
                 document.getElementById('edit-team-device-auth').value = team.device_code_auth_enabled ? '已开启' : '未开启';
+                resetEditTokenRenewUI();
                 showModal('editTeamModal');
             } else {
                 showToast(data.error || '获取信息失败', 'error');
             }
         } catch (error) {
             showToast('网络错误', 'error');
+        }
+    }
+
+    let editOauthDraft = {
+        codeVerifier: '',
+        state: '',
+        clientId: ''
+    };
+
+    function resetEditTokenRenewUI() {
+        const section = document.getElementById('editTeamTokenRenewSection');
+        const urlOutput = document.getElementById('editOAuthAuthorizeUrlOutput');
+        const callbackInput = document.getElementById('editOAuthCallbackInput');
+        if (section) section.style.display = 'none';
+        if (urlOutput) urlOutput.value = '';
+        if (callbackInput) callbackInput.value = '';
+        editOauthDraft = {
+            codeVerifier: '',
+            state: '',
+            clientId: ''
+        };
+    }
+
+    function toggleEditTokenRenewSection() {
+        const section = document.getElementById('editTeamTokenRenewSection');
+        if (!section) return;
+        section.style.display = section.style.display === 'none' ? 'block' : 'none';
+        if (window.lucide) {
+            lucide.createIcons();
+        }
+    }
+
+    async function generateEditOAuthAuthorizeLink() {
+        const clientIdInput = document.getElementById('edit-team-client-id');
+        const defaultClientId = 'app_EMoamEEZ73f0CkXaXp7hrann';
+        const clientId = (clientIdInput && clientIdInput.value ? clientIdInput.value.trim() : '') || defaultClientId;
+
+        showToast('正在生成并复制授权链接...', 'info');
+
+        try {
+            const result = await apiCall('/admin/oauth/openai/authorize', {
+                method: 'POST',
+                body: JSON.stringify({
+                    client_id: clientId,
+                    redirect_uri: 'http://localhost:1455/auth/callback'
+                })
+            });
+
+            if (!result.success) {
+                showToast(result.error || '生成授权链接失败', 'error');
+                return;
+            }
+
+            const data = unwrapApiPayload(result) || {};
+            editOauthDraft.codeVerifier = data.code_verifier || '';
+            editOauthDraft.state = data.state || '';
+            editOauthDraft.clientId = data.client_id || clientId;
+
+            const output = document.getElementById('editOAuthAuthorizeUrlOutput');
+            if (output) output.value = data.authorize_url || '';
+
+            const authUrl = (data.authorize_url || '').trim();
+            if (!authUrl) {
+                showToast('授权链接生成失败，请重试', 'error');
+                return;
+            }
+
+            const copied = await copyTextSilently(authUrl);
+            if (copied) {
+                showToast('链接已复制，去浏览器登录后粘贴回调', 'success');
+            } else {
+                showToast('授权链接已生成，请手动复制', 'warning');
+            }
+        } catch (error) {
+            showToast('生成授权链接失败', 'error');
+        }
+    }
+
+    async function parseEditOAuthCallbackAndFill() {
+        const callbackInput = document.getElementById('editOAuthCallbackInput');
+        const callbackText = callbackInput ? callbackInput.value.trim() : '';
+        const clientIdInput = document.getElementById('edit-team-client-id');
+        const defaultClientId = 'app_EMoamEEZ73f0CkXaXp7hrann';
+        const currentClientId = (clientIdInput && clientIdInput.value ? clientIdInput.value.trim() : '') || editOauthDraft.clientId || defaultClientId;
+
+        if (!callbackText) {
+            showToast('请先粘贴回调 URL', 'error');
+            return;
+        }
+
+        try {
+            const result = await apiCall('/admin/oauth/openai/parse-callback', {
+                method: 'POST',
+                body: JSON.stringify({
+                    callback_text: callbackText,
+                    code_verifier: editOauthDraft.codeVerifier || null,
+                    expected_state: editOauthDraft.state || null,
+                    client_id: currentClientId,
+                    redirect_uri: 'http://localhost:1455/auth/callback'
+                })
+            });
+
+            if (!result.success) {
+                showToast(result.error || '解析回调失败', 'error');
+                return;
+            }
+
+            const parsed = unwrapApiPayload(result) || {};
+            const raw = parsed.raw || {};
+            const accessToken = parsed.access_token || '';
+            const refreshToken = parsed.refresh_token || '';
+            const payload = decodeJwtPayload(accessToken) || {};
+            const accessAuth = payload['https://api.openai.com/auth'] || {};
+            const accessProfile = payload['https://api.openai.com/profile'] || {};
+
+            if (accessToken) document.getElementById('edit-team-token').value = accessToken;
+            if (refreshToken) document.getElementById('edit-team-refresh-token').value = refreshToken;
+
+            const emailInput = document.getElementById('edit-team-email');
+            if (emailInput && !emailInput.value.trim()) {
+                emailInput.value = raw.email || parsed.email || accessProfile.email || '';
+            }
+
+            const accountIdInput = document.getElementById('edit-team-account-id');
+            if (accountIdInput && !accountIdInput.value.trim()) {
+                accountIdInput.value = raw.account_id || parsed.account_id || accessAuth.chatgpt_account_id || '';
+            }
+
+            const teamNameInput = document.getElementById('edit-team-name');
+            if (teamNameInput && !teamNameInput.value.trim()) {
+                teamNameInput.value = raw.team_name || parsed.team_name || accessAuth.chatgpt_org_name || '';
+            }
+
+            showToast('Token 已更新，已按规则补全空白字段，请保存', 'success');
+        } catch (error) {
+            showToast(error.message || '解析回调失败', 'error');
         }
     }
 

--- a/app/utils/jwt_parser.py
+++ b/app/utils/jwt_parser.py
@@ -4,8 +4,10 @@ JWT Token 解析工具
 """
 import jwt
 from typing import Optional, Dict, Any
-from datetime import datetime
+from datetime import datetime, timezone
 import logging
+import pytz
+from app.config import settings
 from app.utils.time_utils import get_now
 
 logger = logging.getLogger(__name__)
@@ -127,7 +129,11 @@ class JWTParser:
         try:
             exp_timestamp = payload.get("exp")
             if exp_timestamp:
-                return datetime.fromtimestamp(exp_timestamp)
+                # exp 是 UTC 时间戳；统一转为系统配置时区的 naive 时间，
+                # 与 get_now() 的返回值保持同一时区语义，避免误判“提前过期”。
+                dt_utc = datetime.fromtimestamp(exp_timestamp, tz=timezone.utc)
+                target_tz = pytz.timezone(settings.timezone)
+                return dt_utc.astimezone(target_tz).replace(tzinfo=None)
             return None
         except Exception as e:
             logger.error(f"获取过期时间失败: {e}")


### PR DESCRIPTION
### Motivation

- Ensure token expiration and remote account `expires_at` timestamps are interpreted in the system-configured timezone to avoid premature expiry decisions.
- Improve robustness of AT refresh logic by preserving a still-valid AT when forced refresh flows fail to avoid incorrectly marking Teams as expired.
- Provide an admin UI to re-run the OAuth flow and paste callback data to quickly replace/renew Team tokens.

### Description

- Added `_parse_remote_expires_at` in `app/services/team.py` to normalize remote ISO expirations into naive datetimes in the system timezone and replaced ad-hoc parsing sites to use it.
- Switched timestamp comparisons from `datetime.now()` to `get_now()` across `TeamService` to maintain consistent timezone semantics.
- In `app/utils/jwt_parser.py` updated `get_expiration_time` to convert `exp` (UTC) to the configured system timezone (using `pytz` and `settings.timezone`) and return a naive datetime, and updated `is_token_expired` to rely on that value.
- Hardened `TeamService.ensure_access_token` to decrypt and check the current AT before attempting refresh, cache a `current_valid_token`, and fall back to it when `force_refresh` fails so a still-valid AT is not discarded.
- Imported `pytz` and `settings` where needed to perform timezone-aware conversions.
- Frontend: extended `app/templates/admin/index.html` with a toggleable Token Renewal section in the Team edit modal and added JS helper functions (`generateEditOAuthAuthorizeLink`, `parseEditOAuthCallbackAndFill`, `toggleEditTokenRenewSection`, `resetEditTokenRenewUI`) to support generating OAuth authorize links and parsing callback URLs, and removed the `?force=true` query from the Team refresh fetch call.

### Testing

- Ran the project test suite with `pytest` and the tests passed (no regressions observed).
- Ran lint checks with `flake8` and static checks passed.
- No new automated tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b7a0849d28832f9d29de941f2fc25b)