### PR TITLE
修复质保期限计算并支持切换质保到期策略

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -4,7 +4,7 @@
 """
 import logging
 import re
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Literal
 from fastapi import APIRouter, Depends, HTTPException, status, Request
 from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
 import json
@@ -17,7 +17,10 @@ from app.dependencies.auth import require_admin
 from app.services.team import TeamService
 from app.services.redemption import RedemptionService
 from app.services.chatgpt import chatgpt_service
-from app.services.settings import settings_service
+from app.services.settings import (
+    settings_service,
+    DEFAULT_WARRANTY_EXPIRATION_MODE,
+)
 from app.models import RedemptionCode, Team
 from app.utils.time_utils import get_now
 
@@ -1609,6 +1612,7 @@ async def settings_page(
                 "periodic_team_sync_interval_hours": await settings_service.get_setting(db, "periodic_team_sync_interval_hours", "12"),
                 "periodic_team_sync_days": await settings_service.get_setting(db, "periodic_team_sync_days", "7"),
                 "default_team_max_members": await settings_service.get_setting(db, "default_team_max_members", "6"),
+                "warranty_expiration_mode": await settings_service.get_warranty_expiration_mode(db),
             }
         )
 
@@ -1655,6 +1659,14 @@ class TeamAutoRefreshSettingsRequest(BaseModel):
     enabled: bool = Field(True, description="是否启用 Team 周期状态自动刷新")
     interval_hours: int = Field(12, ge=1, le=168, description="检查间隔（小时）")
     refresh_interval_days: int = Field(7, ge=1, le=30, description="同步周期（天）")
+
+
+class WarrantyExpirationSettingsRequest(BaseModel):
+    """质保时长计算模式设置请求"""
+    expiration_mode: Literal["first_use", "refresh_on_redeem"] = Field(
+        DEFAULT_WARRANTY_EXPIRATION_MODE,
+        description="质保时长计算模式"
+    )
 
 
 class AnnouncementUpdateRequest(BaseModel):
@@ -1971,6 +1983,50 @@ async def update_team_auto_refresh_settings(
         )
     except Exception as e:
         logger.error(f"更新 Team 自动刷新设置失败: {e}")
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content={"success": False, "error": f"更新失败: {str(e)}"}
+        )
+
+
+@router.post("/settings/warranty")
+async def update_warranty_settings(
+    warranty_data: WarrantyExpirationSettingsRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: dict = Depends(require_admin)
+):
+    """更新质保时长计算模式。"""
+    try:
+        expiration_mode = settings_service.normalize_warranty_expiration_mode(
+            warranty_data.expiration_mode
+        )
+        logger.info("管理员更新质保计算模式: %s", expiration_mode)
+
+        success = await settings_service.update_setting(
+            db,
+            "warranty_expiration_mode",
+            expiration_mode,
+        )
+        if not success:
+            return JSONResponse(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                content={"success": False, "error": "保存失败"}
+            )
+
+        message = (
+            "质保设置已保存：按首次使用时间计算质保期"
+            if expiration_mode == DEFAULT_WARRANTY_EXPIRATION_MODE
+            else "质保设置已保存：质保重兑成功后刷新完整质保期"
+        )
+        return JSONResponse(
+            content={
+                "success": True,
+                "message": message,
+                "expiration_mode": expiration_mode,
+            }
+        )
+    except Exception as e:
+        logger.error(f"更新质保设置失败: {e}")
         return JSONResponse(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             content={"success": False, "error": f"更新失败: {str(e)}"}

--- a/app/services/redeem_flow.py
+++ b/app/services/redeem_flow.py
@@ -17,7 +17,10 @@ from app.services.redemption import RedemptionService
 from app.services.team import TeamService
 from app.services.warranty import warranty_service
 from app.services.notification import notification_service
-from app.services.settings import settings_service
+from app.services.settings import (
+    settings_service,
+    WARRANTY_EXPIRATION_MODE_REFRESH_ON_REDEEM,
+)
 from app.utils.time_utils import get_now
 
 logger = logging.getLogger(__name__)
@@ -315,13 +318,38 @@ class RedeemFlowService:
 
                             # 成功逻辑
                             if rc and (not rc.reusable_by_seat):
+                                warranty_expiration_mode = None
+                                if rc.has_warranty:
+                                    warranty_expiration_mode = await settings_service.get_warranty_expiration_mode(db_session)
+
+                                previous_used_at = rc.used_at
+                                current_use_time = get_now()
                                 rc.status = "used"
                                 rc.used_by_email = email
                                 rc.used_team_id = team_id_final
-                                rc.used_at = get_now()
+                                should_refresh_warranty_window = bool(
+                                    rc.has_warranty and (
+                                        previous_used_at is None
+                                        or warranty_expiration_mode == WARRANTY_EXPIRATION_MODE_REFRESH_ON_REDEEM
+                                    )
+                                )
+
+                                if (not rc.has_warranty) or should_refresh_warranty_window:
+                                    rc.used_at = current_use_time
                                 if rc.has_warranty:
                                     days = rc.warranty_days or 30
-                                    rc.warranty_expires_at = get_now() + timedelta(days=days)
+                                    if should_refresh_warranty_window:
+                                        rc.warranty_expires_at = current_use_time + timedelta(days=days)
+                                    elif not rc.warranty_expires_at:
+                                        base_time = previous_used_at or current_use_time
+                                        first_use_result = await db_session.execute(
+                                            select(func.min(RedemptionRecord.redeemed_at))
+                                            .where(RedemptionRecord.code == code)
+                                        )
+                                        first_use_time = first_use_result.scalar()
+                                        if first_use_time:
+                                            base_time = first_use_time
+                                        rc.warranty_expires_at = base_time + timedelta(days=days)
 
                             if is_virtual_welfare_code:
                                 setting_res = await db_session.execute(

--- a/app/services/redemption.py
+++ b/app/services/redemption.py
@@ -12,6 +12,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.models import RedemptionCode, RedemptionRecord, Team
+from app.services.settings import (
+    settings_service,
+    WARRANTY_EXPIRATION_MODE_REFRESH_ON_REDEEM,
+)
 from app.utils.time_utils import get_now
 
 logger = logging.getLogger(__name__)
@@ -46,6 +50,63 @@ class RedemptionService:
             code = f"{code[0:4]}-{code[4:8]}-{code[8:12]}-{code[12:16]}"
 
         return code
+
+    @staticmethod
+    def _record_sort_key(record: RedemptionRecord) -> tuple[datetime, int]:
+        """按兑换时间和记录 ID 排序，确保重建状态时顺序稳定。"""
+        return (record.redeemed_at or datetime.min, record.id or 0)
+
+    @staticmethod
+    def _clear_code_usage_state(redemption_code: RedemptionCode) -> None:
+        """清空兑换码的使用态字段。"""
+        redemption_code.status = "unused"
+        redemption_code.used_by_email = None
+        redemption_code.used_team_id = None
+        redemption_code.used_at = None
+        redemption_code.warranty_expires_at = None
+
+    async def _rebuild_code_usage_state(
+        self,
+        db_session: AsyncSession,
+        redemption_code: RedemptionCode,
+        excluding_record_id: Optional[int] = None
+    ) -> int:
+        """根据剩余兑换记录重建兑换码状态。"""
+        stmt = select(RedemptionRecord).where(RedemptionRecord.code == redemption_code.code)
+        if excluding_record_id is not None:
+            stmt = stmt.where(RedemptionRecord.id != excluding_record_id)
+
+        stmt = stmt.order_by(RedemptionRecord.redeemed_at.asc(), RedemptionRecord.id.asc())
+        result = await db_session.execute(stmt)
+        remaining_records = result.scalars().all()
+
+        if not remaining_records:
+            self._clear_code_usage_state(redemption_code)
+            return 0
+
+        first_record = remaining_records[0]
+        latest_record = max(remaining_records, key=self._record_sort_key)
+
+        redemption_code.status = "used"
+        redemption_code.used_by_email = latest_record.email
+        redemption_code.used_team_id = latest_record.team_id
+
+        if redemption_code.has_warranty:
+            expiration_mode = await settings_service.get_warranty_expiration_mode(db_session)
+            base_record = (
+                latest_record
+                if expiration_mode == WARRANTY_EXPIRATION_MODE_REFRESH_ON_REDEEM
+                else first_record
+            )
+            base_time = base_record.redeemed_at or get_now()
+            redemption_code.used_at = base_time
+            days = redemption_code.warranty_days or 30
+            redemption_code.warranty_expires_at = base_time + timedelta(days=days)
+        else:
+            redemption_code.used_at = latest_record.redeemed_at or get_now()
+            redemption_code.warranty_expires_at = None
+
+        return len(remaining_records)
 
     async def generate_code_single(
         self,
@@ -888,19 +949,15 @@ class RedemptionService:
                         "error": f"从 Team 移除成员失败: {team_result.get('error') or team_result.get('message')}"
                     }
 
-            # 3. 恢复兑换码状态
+            # 3. 根据剩余记录重建兑换码状态
             code = record.redemption_code
+            remaining_records_count = 0
             if code:
-                # 如果是质保兑换，且还有其他记录，状态可能不应该直接回 unused
-                # 但根据逻辑，目前一个码一个记录（除了质保补发可能产生新记录，但那是两个不同的码吧？）
-                # 查了一下模型，RedemptionCode 有 used_by_email 等字段，说明它是单次使用的设计
-                code.status = "unused"
-                code.used_by_email = None
-                code.used_team_id = None
-                code.used_at = None
-                # 特殊处理质保字段
-                if code.has_warranty:
-                    code.warranty_expires_at = None
+                remaining_records_count = await self._rebuild_code_usage_state(
+                    db_session,
+                    code,
+                    excluding_record_id=record.id
+                )
 
             # 4. 删除使用记录
             await db_session.delete(record)
@@ -908,9 +965,14 @@ class RedemptionService:
 
             logger.info(f"撤回记录成功: {record_id}, 邮箱: {record.email}, 兑换码: {record.code}")
 
+            if code and remaining_records_count > 0:
+                message = f"成功撤回记录，兑换码 {record.code} 已按剩余 {remaining_records_count} 条记录重建状态"
+            else:
+                message = f"成功撤回记录并恢复兑换码 {record.code}"
+
             return {
                 "success": True,
-                "message": f"成功撤回记录并恢复兑换码 {record.code}"
+                "message": message
             }
 
         except Exception as e:

--- a/app/services/settings.py
+++ b/app/services/settings.py
@@ -10,12 +10,28 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+WARRANTY_EXPIRATION_MODE_FIRST_USE = "first_use"
+WARRANTY_EXPIRATION_MODE_REFRESH_ON_REDEEM = "refresh_on_redeem"
+DEFAULT_WARRANTY_EXPIRATION_MODE = WARRANTY_EXPIRATION_MODE_FIRST_USE
+VALID_WARRANTY_EXPIRATION_MODES = {
+    WARRANTY_EXPIRATION_MODE_FIRST_USE,
+    WARRANTY_EXPIRATION_MODE_REFRESH_ON_REDEEM,
+}
+
 
 class SettingsService:
     """系统设置服务类"""
 
     def __init__(self):
         self._cache: Dict[str, str] = {}
+
+    @staticmethod
+    def normalize_warranty_expiration_mode(mode: Optional[str]) -> str:
+        """规范化质保时长计算模式。"""
+        normalized = str(mode or "").strip().lower()
+        if normalized in VALID_WARRANTY_EXPIRATION_MODES:
+            return normalized
+        return DEFAULT_WARRANTY_EXPIRATION_MODE
 
     async def get_setting(self, session: AsyncSession, key: str, default: Optional[str] = None) -> Optional[str]:
         """
@@ -214,6 +230,15 @@ class SettingsService:
             logger.info(f"日志级别已更新为: {level.upper()}")
 
         return success
+
+    async def get_warranty_expiration_mode(self, session: AsyncSession) -> str:
+        """获取质保时长计算模式。"""
+        raw_value = await self.get_setting(
+            session,
+            "warranty_expiration_mode",
+            DEFAULT_WARRANTY_EXPIRATION_MODE,
+        )
+        return self.normalize_warranty_expiration_mode(raw_value)
 
 
 # 创建全局实例

--- a/app/services/warranty.py
+++ b/app/services/warranty.py
@@ -6,11 +6,15 @@ import logging
 import asyncio
 from typing import Optional, Dict, Any, List
 from datetime import datetime, timedelta
-from sqlalchemy import select, and_, or_, delete
+from sqlalchemy import select, and_, or_, delete, func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.models import RedemptionCode, RedemptionRecord, Team
+from app.services.settings import (
+    settings_service,
+    WARRANTY_EXPIRATION_MODE_REFRESH_ON_REDEEM,
+)
 from app.utils.time_utils import get_now
 
 logger = logging.getLogger(__name__)
@@ -27,6 +31,64 @@ class WarrantyService:
         """初始化质保服务"""
         from app.services.team import TeamService
         self.team_service = TeamService()
+
+    async def _get_warranty_start_time(
+        self,
+        db_session: AsyncSession,
+        redemption_code: RedemptionCode,
+        reference_record: Optional[RedemptionRecord] = None,
+        expiration_mode: Optional[str] = None
+    ) -> Optional[datetime]:
+        """根据当前模式解析质保起算时间。"""
+        mode = expiration_mode or await settings_service.get_warranty_expiration_mode(db_session)
+
+        if mode == WARRANTY_EXPIRATION_MODE_REFRESH_ON_REDEEM:
+            return redemption_code.used_at or (reference_record.redeemed_at if reference_record else None)
+
+        result = await db_session.execute(
+            select(func.min(RedemptionRecord.redeemed_at))
+            .where(RedemptionRecord.code == redemption_code.code)
+        )
+        first_redeemed_at = result.scalar()
+
+        return first_redeemed_at or redemption_code.used_at or (reference_record.redeemed_at if reference_record else None)
+
+    async def _resolve_warranty_expiry_date(
+        self,
+        db_session: AsyncSession,
+        redemption_code: RedemptionCode,
+        reference_record: Optional[RedemptionRecord] = None,
+        expiration_mode: Optional[str] = None
+    ) -> Optional[datetime]:
+        """获取质保截止时间，必要时按当前模式动态回退计算。"""
+        if not redemption_code.has_warranty:
+            return None
+
+        if redemption_code.warranty_expires_at:
+            return redemption_code.warranty_expires_at
+
+        start_time = await self._get_warranty_start_time(
+            db_session,
+            redemption_code,
+            reference_record=reference_record,
+            expiration_mode=expiration_mode
+        )
+        if not start_time:
+            return None
+
+        days = redemption_code.warranty_days or 30
+        return start_time + timedelta(days=days)
+
+    @staticmethod
+    def _is_warranty_valid(redemption_code: RedemptionCode, expiry_date: Optional[datetime]) -> bool:
+        """根据截止时间和码状态判断质保是否有效。"""
+        if expiry_date:
+            return expiry_date >= get_now()
+
+        if redemption_code.has_warranty and redemption_code.status == "unused":
+            return True
+
+        return False
 
     async def check_warranty_status(
         self,
@@ -64,6 +126,7 @@ class WarrantyService:
                     "error": f"查询太频繁,请 {wait_time} 秒后再试"
                 }
             _query_rate_limit[limit_key] = now
+            warranty_expiration_mode = await settings_service.get_warranty_expiration_mode(db_session)
 
             # 1. 查找兑换记录和相关联的 Team, Code
             records_data = []
@@ -103,27 +166,34 @@ class WarrantyService:
                             "records": [],
                             "message": "兑换码不存在"
                         }
-                    
+
+                    expiry_date = await self._resolve_warranty_expiry_date(
+                        db_session,
+                        redemption_code_obj,
+                        expiration_mode=warranty_expiration_mode
+                    )
+                    is_valid = self._is_warranty_valid(redemption_code_obj, expiry_date)
+
                     # 只有码没有记录的情况
                     return {
                         "success": True,
                         "has_warranty": redemption_code_obj.has_warranty,
-                        "warranty_valid": True if not redemption_code_obj.warranty_expires_at or redemption_code_obj.warranty_expires_at > get_now() else False,
-                        "warranty_expires_at": redemption_code_obj.warranty_expires_at.isoformat() if redemption_code_obj.warranty_expires_at else None,
+                        "warranty_valid": is_valid,
+                        "warranty_expires_at": expiry_date.isoformat() if expiry_date else None,
                         "banned_teams": [],
                         "can_reuse": False,
                         "original_code": redemption_code_obj.code,
                         "records": [{
                             "code": redemption_code_obj.code,
                             "has_warranty": redemption_code_obj.has_warranty,
-                            "warranty_valid": True if not redemption_code_obj.warranty_expires_at or redemption_code_obj.warranty_expires_at > get_now() else False,
+                            "warranty_valid": is_valid,
                             "status": redemption_code_obj.status,
                             "used_at": None,
                             "team_id": None,
                             "team_name": None,
                             "team_status": None,
                             "team_expires_at": None,
-                            "warranty_expires_at": redemption_code_obj.warranty_expires_at.isoformat() if redemption_code_obj.warranty_expires_at else None
+                            "warranty_expires_at": expiry_date.isoformat() if expiry_date else None
                         }],
                         "message": "兑换码尚未被使用"
                     }
@@ -189,24 +259,13 @@ class WarrantyService:
                         continue 
 
                 # 动态计算/提取质保信息
-                expiry_date = code_obj.warranty_expires_at
-                
-                # 如果是质保码且已使用，但到期时间为空，尝试动态计算
-                if code_obj.has_warranty and not expiry_date:
-                    start_time = code_obj.used_at or record.redeemed_at # 优先取首次使用时间
-                    if start_time:
-                        days = code_obj.warranty_days or 30
-                        expiry_date = start_time + timedelta(days=days)
-
-                is_valid = True
-                if expiry_date and expiry_date < get_now():
-                    is_valid = False
-                elif not expiry_date and code_obj.has_warranty and code_obj.status == "unused":
-                    # 未使用的质保码，暂时标记为有效
-                    is_valid = True
-                elif not expiry_date:
-                    # 既没日期也没记录，通常是非质保码
-                    is_valid = False
+                expiry_date = await self._resolve_warranty_expiry_date(
+                    db_session,
+                    code_obj,
+                    reference_record=record,
+                    expiration_mode=warranty_expiration_mode
+                )
+                is_valid = self._is_warranty_valid(code_obj, expiry_date)
 
                 if code_obj.has_warranty:
                     has_any_warranty = True
@@ -313,14 +372,14 @@ class WarrantyService:
                 }
 
             # 3. 检查质保期是否有效
-            if redemption_code.warranty_expires_at:
-                if redemption_code.warranty_expires_at < get_now():
-                    return {
-                        "success": True,
-                        "can_reuse": False,
-                        "reason": "质保已过期",
-                        "error": None
-                    }
+            expiry_date = await self._resolve_warranty_expiry_date(db_session, redemption_code)
+            if expiry_date and expiry_date < get_now():
+                return {
+                    "success": True,
+                    "can_reuse": False,
+                    "reason": "质保已过期",
+                    "error": None
+                }
 
             # 4. 检查该兑换码当前是否已有正在使用的活跃 Team (全局检查，不限邮箱)
             # 逻辑：如果该码名下有任何一个 Team 还是 active/full 状态且未过期，则不允许新的激活

--- a/app/templates/admin/records/index.html
+++ b/app/templates/admin/records/index.html
@@ -265,7 +265,7 @@
 {% block extra_js %}
 <script>
     async function withdrawRecord(recordId, email) {
-        if (!confirm(`确定要撤回针对 ${email} 的兑换记录吗？\n\n这将执行以下操作：\n1. 在 ChatGPT Team 中撤回邀请或删除成员\n2. 恢复对应的兑换码为“未使用”状态\n3. 删除此条使用记录`)) {
+        if (!confirm(`确定要撤回针对 ${email} 的兑换记录吗？\n\n这将执行以下操作：\n1. 在 ChatGPT Team 中撤回邀请或删除成员\n2. 按剩余使用记录重建兑换码状态\n3. 删除此条使用记录`)) {
             return;
         }
 

--- a/app/templates/admin/settings/index.html
+++ b/app/templates/admin/settings/index.html
@@ -12,6 +12,7 @@
     <a href="#settings-log" class="settings-nav-pill settings-nav-link" data-target="settings-log">日志级别</a>
     <a href="#settings-refresh" class="settings-nav-pill settings-nav-link" data-target="settings-refresh">Token 预刷新</a>
     <a href="#settings-team-auto-refresh" class="settings-nav-pill settings-nav-link" data-target="settings-team-auto-refresh">Team 自动刷新</a>
+    <a href="#settings-warranty" class="settings-nav-pill settings-nav-link" data-target="settings-warranty">质保设置</a>
     <a href="#settings-team-import" class="settings-nav-pill settings-nav-link" data-target="settings-team-import">Team 导入</a>
     <a href="#settings-webhook" class="settings-nav-pill settings-nav-link" data-target="settings-webhook">库存预警</a>
 </div>
@@ -160,6 +161,31 @@
         </div>
 
         <button type="submit" class="btn btn-primary">保存 Team 自动刷新配置</button>
+    </form>
+</div>
+
+
+<!-- 质保设置 -->
+<div class="content-section settings-panel" id="settings-warranty">
+    <div class="section-header">
+        <h3>质保设置</h3>
+    </div>
+
+    <form id="warrantySettingsForm" class="settings-form">
+        <div class="form-group">
+            <label for="warrantyExpirationMode">质保时长计算方式</label>
+            <select id="warrantyExpirationMode" name="expiration_mode" class="form-control">
+                <option value="first_use" {% if (warranty_expiration_mode or 'first_use') == 'first_use' %}selected{% endif %}>
+                    首次使用后开始计算
+                </option>
+                <option value="refresh_on_redeem" {% if warranty_expiration_mode == 'refresh_on_redeem' %}selected{% endif %}>
+                    每次质保重兑成功后刷新
+                </option>
+            </select>
+            <p class="form-help">默认推荐“首次使用后开始计算”。开启刷新模式后，用户每次质保重兑成功都会重新获得完整质保时长。</p>
+        </div>
+
+        <button type="submit" class="btn btn-primary">保存质保设置</button>
     </form>
 </div>
 
@@ -453,6 +479,33 @@
 
             if (response.ok && data.success) {
                 showToast(data.message || 'Team 自动刷新配置已保存', 'success');
+            } else {
+                showToast(data.error || '保存失败', 'error');
+            }
+        } catch (error) {
+            showToast('网络错误', 'error');
+        }
+    });
+
+    // 质保设置表单
+    document.getElementById('warrantySettingsForm').addEventListener('submit', async (e) => {
+        e.preventDefault();
+
+        const expiration_mode = document.getElementById('warrantyExpirationMode').value;
+
+        try {
+            const response = await fetch('/admin/settings/warranty', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ expiration_mode })
+            });
+
+            const data = await response.json();
+
+            if (response.ok && data.success) {
+                showToast(data.message || '质保设置已保存', 'success');
             } else {
                 showToast(data.error || '保存失败', 'error');
             }

--- a/init_db.py
+++ b/init_db.py
@@ -59,6 +59,11 @@ async def create_default_settings():
                 value="6",
                 description="新导入 Team 的默认总席位"
             ),
+            Setting(
+                key="warranty_expiration_mode",
+                value="first_use",
+                description="质保时长计算模式: first_use/refresh_on_redeem"
+            ),
         ]
 
         session.add_all(default_settings)


### PR DESCRIPTION
## 变更说明
- 新增系统设置开关，支持在“首次使用后开始计算质保期”和“每次质保重兑成功后刷新完整质保期”之间切换
- 默认采用“首次使用后开始计算质保期”，并为新库初始化默认设置项
- 调整兑换与质保查询逻辑，默认情况下不会在质保重兑后重置质保截止时间
- 修复管理员撤回单条使用记录时会错误清空整张兑换码状态的问题，改为按剩余使用记录重建状态
- 更新后台设置页与撤回记录提示文案，使界面行为与实际逻辑一致

## 验证
- 运行 `python -m py_compile app/services/settings.py app/services/redeem_flow.py app/services/warranty.py app/services/redemption.py app/routes/admin.py init_db.py`
- 运行 `git diff --check`