### PR TITLE
Fix exported OAuth JSON template

### DIFF
--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -508,15 +508,17 @@ function toIsoStringWithOffset8(dateObj) {
 function buildOAuthJsonTemplate(parsedData) {
     const accessToken = parsedData.access_token || '';
     const refreshToken = parsedData.refresh_token || '';
-    const clientId = parsedData.client_id || '';
     const raw = parsedData.raw || {};
+    const idToken = raw.id_token || parsedData.id_token || '';
 
     const accessPayload = decodeJwtPayload(accessToken) || {};
+    const idPayload = decodeJwtPayload(idToken) || {};
     const accessAuth = accessPayload['https://api.openai.com/auth'] || {};
     const accessProfile = accessPayload['https://api.openai.com/profile'] || {};
+    const idAuth = idPayload['https://api.openai.com/auth'] || {};
 
-    const accountId = raw.account_id || parsedData.account_id || accessAuth.chatgpt_account_id || '';
-    const email = raw.email || parsedData.email || accessProfile.email || '';
+    const accountId = raw.account_id || parsedData.account_id || accessAuth.chatgpt_account_id || idAuth.chatgpt_account_id || '';
+    const email = raw.email || parsedData.email || accessProfile.email || idPayload.email || '';
     const exp = accessPayload.exp ? new Date(accessPayload.exp * 1000) : null;
     const expired = raw.expired || parsedData.expired || (exp ? toIsoStringWithOffset8(exp) : '');
 
@@ -526,11 +528,10 @@ function buildOAuthJsonTemplate(parsedData) {
         disabled: typeof raw.disabled === 'boolean' ? raw.disabled : false,
         email,
         expired,
-        id_token: raw.id_token || parsedData.id_token || '',
+        id_token: idToken,
         last_refresh: raw.last_refresh || parsedData.last_refresh || toIsoStringWithOffset8(new Date()),
         refresh_token: refreshToken,
-        type: raw.type || parsedData.type || 'codex',
-        client_id: clientId
+        type: raw.type || parsedData.type || 'codex'
     };
 }
 


### PR DESCRIPTION
### Motivation
- 导出的 OAuth JSON 与 CPA 官方模板字段不一致，导致导出的文件缺少或错置官方要求的账号元数据。
- 需要在无法从 `access_token` 中获取 `account_id`/`email` 时使用 `id_token` 作为兜底，以降低导出文件缺少 ChatGPT 账号 ID 的概率。

### Description
- 更新了 `buildOAuthJsonTemplate` 实现（文件 `app/static/js/main.js`），在生成导出 JSON 前解析 `id_token` 并解码其 payload 以作补充来源。
- 从 `access_token` 和 `id_token` 的解析结果中优先提取 `account_id` 与 `email`（`access_token` 优先，`id_token` 兜底）。
- 停止将 `client_id` 写入导出文件，并将 `id_token` 字段改为使用解析得到的 `idToken` 值返回，最终导出字段集合与官方样例对齐（`access_token`、`account_id`、`disabled`、`email`、`expired`、`id_token`、`last_refresh`、`refresh_token`、`type`）。

### Testing
- 已用 `python -m compileall app` 编译检查项目 Python 代码，编译无异常。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ba15dca9c4832f8f9438880328384c)