### PR TITLE
Fix admin status filter query handling

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -134,6 +134,7 @@ async def admin_dashboard(
     per_page: int = 20,
     search: Optional[str] = None,
     status_filter: Optional[str] = None,
+    status: Optional[str] = None,
     db: AsyncSession = Depends(get_db),
     current_user: dict = Depends(require_admin)
 ):
@@ -142,7 +143,10 @@ async def admin_dashboard(
     """
     try:
         from app.main import templates
-        logger.info(f"管理员访问控制台, search={search}, page={page}, per_page={per_page}")
+        if status_filter is None and status is not None:
+            status_filter = status
+
+        logger.info(f"管理员访问控制台, search={search}, page={page}, per_page={per_page}, status_filter={status_filter}")
 
         # 设置每页数量
         # per_page = 20 (Removed hardcoded value)
@@ -200,12 +204,16 @@ async def welfare_dashboard(
     per_page: int = 20,
     search: Optional[str] = None,
     status_filter: Optional[str] = None,
+    status: Optional[str] = None,
     db: AsyncSession = Depends(get_db),
     current_user: dict = Depends(require_admin)
 ):
     """福利车位管理页"""
     try:
         from app.main import templates
+
+        if status_filter is None and status is not None:
+            status_filter = status
 
         teams_result = await team_service.get_all_teams(db, page=page, per_page=per_page, search=search, status=status_filter, pool_type="welfare")
         team_stats = await team_service.get_stats(db, pool_type="welfare")

--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -131,7 +131,7 @@
                     </a>
                     {% endif %}
                     {% if status_filter %}
-                    <input type="hidden" name="status" value="{{ status_filter }}">
+                    <input type="hidden" name="status_filter" value="{{ status_filter }}">
                     {% endif %}
                 </div>
             </form>
@@ -901,9 +901,9 @@
     function filterByStatus(status) {
         const url = new URL(window.location.href);
         if (status) {
-            url.searchParams.set('status', status);
+            url.searchParams.set('status_filter', status);
         } else {
-            url.searchParams.delete('status');
+            url.searchParams.delete('status_filter');
         }
         url.searchParams.set('page', 1);
         window.location.href = url.toString();


### PR DESCRIPTION
### Motivation
- 用户在管理员页面点击状态筛选后列表没有变化是因为前端和后端使用了不同的查询参数名，前端发送 `status` 而后端读取 `status_filter`，导致筛选条件未传入查询逻辑。 

### Description
- 修改模板 `app/templates/admin/index.html` 将隐藏字段和前端 JS 的查询参数统一为 `status_filter`，并将 `filterByStatus` 中对 URL 的读写改为 `status_filter`。 
- 在后台路由 `app/routes/admin.py` 的首页和福利页处理函数中新增对旧参数 `status` 的兼容：当 `status_filter` 为空且 `status` 存在时将其赋值给 `status_filter`，从而保持向后兼容。 
- 保持搜索表单在分页/筛选时能携带状态参数，避免搜索或切换页面时丢失筛选条件。 

### Testing
- 运行了 `python -m py_compile app/routes/admin.py app/services/team.py`，语法校验通过。 
- 使用 `git diff` 验证了对 `app/routes/admin.py` 和 `app/templates/admin/index.html` 的变更内容符合预期。 
- 页面端的浏览器截图/运行验证未在当前环境执行，因为没有可用的浏览器容器工具。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69babc3584e88330a8ef89f6edd67f96)