### PR TITLE
Add batch Access Token paste UI and tweak admin sidebar/overlay styles

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1108,6 +1108,24 @@ body.admin-theme .toast {
     word-break: break-word;
 }
 
+
+.batch-token-input-box {
+    margin-bottom: 1rem;
+}
+
+.batch-token-input-title {
+    display: inline-block;
+    margin-bottom: 0.5rem;
+    font-weight: 700;
+    color: var(--text-main);
+}
+
+.batch-token-textarea {
+    min-height: 180px;
+    resize: vertical;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
 .import-mode-toggle-wrap {
     margin: 0.75rem 0 1rem;
     text-align: center;
@@ -1424,6 +1442,18 @@ body.admin-theme .toast {
         box-shadow: var(--shadow-lg);
         width: 280px;
         height: 100vh;
+        background-color: var(--bg-surface);
+    }
+
+    body.admin-theme .sidebar {
+        background-color: #0b1733;
+        backdrop-filter: none;
+        -webkit-backdrop-filter: none;
+    }
+
+    body.admin-theme.theme-warm .sidebar,
+    html.theme-warm body.admin-theme .sidebar {
+        background-color: #fffaf4;
     }
 
     .sidebar.open {
@@ -1436,8 +1466,7 @@ body.admin-theme .toast {
         left: 0;
         right: 0;
         bottom: 0;
-        background-color: rgba(0, 0, 0, 0.4);
-        backdrop-filter: blur(4px);
+        background-color: rgba(0, 0, 0, 0.28);
         z-index: 1000;
         opacity: 0;
         pointer-events: none;

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -220,7 +220,18 @@
                             <button type="button" id="chooseJsonFileBtn" class="btn btn-primary">选择 JSON 文件</button>
                             <div class="json-import-file-hint" id="jsonImportFileName">支持单对象、对象数组，或 {"teams": [...]} 格式</div>
                         </div>
-                        <textarea name="batchContent" style="display:none"></textarea>
+                        <div class="batch-token-input-box">
+                            <label for="batchAccessTokens" class="batch-token-input-title">或直接粘贴 Access Token</label>
+                            <textarea id="batchAccessTokens" name="batchContent" class="form-control batch-token-textarea" rows="8" placeholder="每行粘贴一个 Access Token (AT)，系统会自动解析账号信息
+
+eyJ...
+eyJ...
+eyJ..."></textarea>
+                            <small class="form-text">一行一个 AT，粘贴后点击下方“批量导入”即可自动解析邮箱与账号信息。</small>
+                        </div>
+                        <div class="form-actions" style="margin-bottom: 1rem;">
+                            <button type="submit" class="btn btn-primary">批量导入</button>
+                        </div>
                         <div id="batchProgressContainer" style="display: none; margin-bottom: 1.5rem;">
                             <div class="progress-info"
                                 style="display: flex; justify-content: space-between; margin-bottom: 0.5rem; font-size: 0.875rem;">


### PR DESCRIPTION
### Motivation
- Provide a direct way to paste multiple Access Tokens to simplify batch account imports.
- Make the batch-import input clearer with a dedicated textarea, placeholder, and helper text to improve user guidance.
- Improve visual contrast and polish for the admin sidebar and its overlay across themes.

### Description
- Added styles for batch input in `app/static/css/style.css` including `.batch-token-input-box`, `.batch-token-input-title`, and `.batch-token-textarea` with a monospace font and `min-height` for comfortable multi-line input.
- Updated sidebar and overlay visuals in `app/static/css/style.css` by setting `background-color` for `.sidebar`, adding `body.admin-theme .sidebar` and warm-theme overrides, and reducing `.sidebar-overlay` opacity from `0.4` to `0.28`.
- Replaced the hidden textarea in `app/templates/base.html` with a visible textarea `id="batchAccessTokens"` bound to `name="batchContent"`, added a submit button (`批量导入`), placeholder examples, and explanatory helper text to support one-AT-per-line batch imports.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb5a2cd80483308c5da0740f021961)