### PR TITLE
Add batch-token textarea + reset logic for batch import and improve mobile/admin sidebar styles

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1108,6 +1108,24 @@ body.admin-theme .toast {
     word-break: break-word;
 }
 
+
+.batch-token-input-box {
+    margin-bottom: 1rem;
+}
+
+.batch-token-input-title {
+    display: inline-block;
+    margin-bottom: 0.5rem;
+    font-weight: 700;
+    color: var(--text-main);
+}
+
+.batch-token-textarea {
+    min-height: 180px;
+    resize: vertical;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
 .import-mode-toggle-wrap {
     margin: 0.75rem 0 1rem;
     text-align: center;
@@ -1387,6 +1405,11 @@ body.admin-theme .toast {
         padding: 0 1rem;
     }
 
+    body.admin-theme .main-container {
+        position: static;
+        z-index: auto;
+    }
+
     .navbar-left {
         display: flex;
         align-items: center;
@@ -1424,6 +1447,18 @@ body.admin-theme .toast {
         box-shadow: var(--shadow-lg);
         width: 280px;
         height: 100vh;
+        background-color: var(--bg-surface);
+    }
+
+    body.admin-theme .sidebar {
+        background-color: #0b1733;
+        backdrop-filter: none;
+        -webkit-backdrop-filter: none;
+    }
+
+    body.admin-theme.theme-warm .sidebar,
+    html.theme-warm body.admin-theme .sidebar {
+        background-color: #fffaf4;
     }
 
     .sidebar.open {
@@ -1436,8 +1471,7 @@ body.admin-theme .toast {
         left: 0;
         right: 0;
         bottom: 0;
-        background-color: rgba(0, 0, 0, 0.4);
-        backdrop-filter: blur(4px);
+        background-color: rgba(0, 0, 0, 0.28);
         z-index: 1000;
         opacity: 0;
         pointer-events: none;

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -304,11 +304,32 @@ function showModal(modalId) {
     }
 }
 
+function resetBatchImportForm() {
+    const form = document.getElementById('batchImportForm');
+    if (!form) return;
+
+    form.reset();
+
+    const fileInput = document.getElementById('jsonImportFile');
+    if (fileInput) {
+        fileInput.value = '';
+    }
+
+    const fileNameNode = document.getElementById('jsonImportFileName');
+    if (fileNameNode) {
+        fileNameNode.textContent = '支持单对象、对象数组，或 {"teams": [...]} 格式';
+    }
+}
+
 function hideModal(modalId) {
     const modal = document.getElementById(modalId);
     if (modal) {
         modal.classList.remove('show');
         document.body.style.overflow = '';
+
+        if (modalId === 'importTeamModal') {
+            resetBatchImportForm();
+        }
     }
 }
 
@@ -761,6 +782,7 @@ async function handleBatchImport(event) {
     } catch (error) {
         showToast(error.message || '网络错误', 'error');
     } finally {
+        resetBatchImportForm();
         submitButton.disabled = false;
         submitButton.textContent = '批量导入';
     }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -220,7 +220,18 @@
                             <button type="button" id="chooseJsonFileBtn" class="btn btn-primary">选择 JSON 文件</button>
                             <div class="json-import-file-hint" id="jsonImportFileName">支持单对象、对象数组，或 {"teams": [...]} 格式</div>
                         </div>
-                        <textarea name="batchContent" style="display:none"></textarea>
+                        <div class="batch-token-input-box">
+                            <label for="batchAccessTokens" class="batch-token-input-title">或直接粘贴 Access Token</label>
+                            <textarea id="batchAccessTokens" name="batchContent" class="form-control batch-token-textarea" rows="8" placeholder="每行粘贴一个 Access Token (AT)，系统会自动解析账号信息
+
+eyJ...
+eyJ...
+eyJ..."></textarea>
+                            <small class="form-text">一行一个 AT，粘贴后点击下方“批量导入”即可自动解析邮箱与账号信息。</small>
+                        </div>
+                        <div class="form-actions" style="margin-bottom: 1rem;">
+                            <button type="submit" class="btn btn-primary">批量导入</button>
+                        </div>
                         <div id="batchProgressContainer" style="display: none; margin-bottom: 1.5rem;">
                             <div class="progress-info"
                                 style="display: flex; justify-content: space-between; margin-bottom: 0.5rem; font-size: 0.875rem;">


### PR DESCRIPTION
### Motivation

- Provide a direct textarea option to paste multiple Access Tokens for batch import in addition to JSON file upload. 
- Ensure import modal form state is cleared when closed or after a batch import to avoid stale inputs. 
- Improve mobile sidebar visuals and admin-theme styling (backgrounds, overlay opacity and stacking) for better UX on small screens. 

### Description

- Added a new batch tokens input area in the import modal by replacing the hidden `textarea` with a visible `textarea` (`#batchAccessTokens`) and associated labels/help text and submit button. 
- Implemented `resetBatchImportForm()` in `app/static/js/main.js` to clear the form, reset the file input, and restore the helper filename text, and wired it to run after a batch import and when closing the `importTeamModal`. 
- Updated streaming import flow to call `resetBatchImportForm()` in the `finally` block of `handleBatchImport`. 
- Extended CSS (`app/static/css/style.css`) with styles for the new `.batch-token-*` classes, tuned mobile behavior for `.sidebar`, `.sidebar-overlay`, and `body.admin-theme` (background colors, backdrop-filter removal, overlay opacity change, and `main-container` stacking fix). 

### Testing

- Ran the project's frontend linter (`npm run lint`) against modified JS/CSS files and it passed. 
- Ran the backend test suite with `pytest` and all tests passed. 
- Performed an automated smoke test of the import flow (form reset after cancel and after import) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb5a2cd80483308c5da0740f021961)