### PR TITLE
Add batch Access Token paste UI and form reset; refine sidebar/layout and mobile styles

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -266,7 +266,8 @@ body.admin-theme .toast {
 
 .main-container {
     display: flex;
-    align-items: stretch;
+    align-items: flex-start;
+    flex-wrap: nowrap;
     max-width: 1440px;
     margin: 0 auto;
 }
@@ -274,6 +275,7 @@ body.admin-theme .toast {
 .sidebar {
     width: 260px;
     flex-shrink: 0;
+    align-self: flex-start;
     padding: 2rem 1.5rem;
     border-right: 1px solid var(--border-base);
     min-height: calc(100vh - 64px);
@@ -319,7 +321,8 @@ body.admin-theme .toast {
 }
 
 .main-content {
-    flex: 1;
+    flex: 1 1 auto;
+    width: calc(100% - 260px);
     min-width: 0;
     /* Allow content to shrink and trigger scrolling */
     padding: 2rem 3rem;
@@ -1108,6 +1111,24 @@ body.admin-theme .toast {
     word-break: break-word;
 }
 
+
+.batch-token-input-box {
+    margin-bottom: 1rem;
+}
+
+.batch-token-input-title {
+    display: inline-block;
+    margin-bottom: 0.5rem;
+    font-weight: 700;
+    color: var(--text-main);
+}
+
+.batch-token-textarea {
+    min-height: 180px;
+    resize: vertical;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
 .import-mode-toggle-wrap {
     margin: 0.75rem 0 1rem;
     text-align: center;
@@ -1383,8 +1404,17 @@ body.admin-theme .toast {
 }
 
 @media (max-width: 768px) {
+    :root {
+        --mobile-sidebar-width: min(280px, calc(100vw - 56px));
+    }
+
     .navbar-container {
         padding: 0 1rem;
+    }
+
+    body.admin-theme .main-container {
+        position: static;
+        z-index: auto;
     }
 
     .navbar-left {
@@ -1422,8 +1452,20 @@ body.admin-theme .toast {
         transform: translateX(-100%);
         transition: transform var(--transition-base);
         box-shadow: var(--shadow-lg);
-        width: 280px;
+        width: var(--mobile-sidebar-width);
         height: 100vh;
+        background-color: var(--bg-surface);
+    }
+
+    body.admin-theme .sidebar {
+        background-color: #0b1733;
+        backdrop-filter: none;
+        -webkit-backdrop-filter: none;
+    }
+
+    body.admin-theme.theme-warm .sidebar,
+    html.theme-warm body.admin-theme .sidebar {
+        background-color: #fffaf4;
     }
 
     .sidebar.open {
@@ -1431,22 +1473,7 @@ body.admin-theme .toast {
     }
 
     .sidebar-overlay {
-        position: fixed;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background-color: rgba(0, 0, 0, 0.4);
-        backdrop-filter: blur(4px);
-        z-index: 1000;
-        opacity: 0;
-        pointer-events: none;
-        transition: opacity var(--transition-base);
-    }
-
-    .sidebar-overlay.show {
-        opacity: 1;
-        pointer-events: auto;
+        display: none;
     }
 
     .main-content {

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -304,11 +304,32 @@ function showModal(modalId) {
     }
 }
 
+function resetBatchImportForm() {
+    const form = document.getElementById('batchImportForm');
+    if (!form) return;
+
+    form.reset();
+
+    const fileInput = document.getElementById('jsonImportFile');
+    if (fileInput) {
+        fileInput.value = '';
+    }
+
+    const fileNameNode = document.getElementById('jsonImportFileName');
+    if (fileNameNode) {
+        fileNameNode.textContent = '支持单对象、对象数组，或 {"teams": [...]} 格式';
+    }
+}
+
 function hideModal(modalId) {
     const modal = document.getElementById(modalId);
     if (modal) {
         modal.classList.remove('show');
         document.body.style.overflow = '';
+
+        if (modalId === 'importTeamModal') {
+            resetBatchImportForm();
+        }
     }
 }
 
@@ -654,6 +675,7 @@ async function handleBatchImport(event) {
 
     submitButton.disabled = true;
     submitButton.textContent = '导入中...';
+    let shouldResetBatchForm = false;
 
     try {
         const response = await fetch('/admin/teams/import', {
@@ -724,6 +746,7 @@ async function handleBatchImport(event) {
                     finalSummaryEl.textContent = `总数: ${data.total} | 成功: ${data.success_count} | 失败: ${data.failed_count}`;
 
                     if (data.failed_count === 0) {
+                        shouldResetBatchForm = true;
                         showToast('全部导入成功！', 'success');
                     } else {
                         showToast(`导入完成，成功 ${data.success_count} 条，失败 ${data.failed_count} 条`, 'warning');
@@ -761,6 +784,9 @@ async function handleBatchImport(event) {
     } catch (error) {
         showToast(error.message || '网络错误', 'error');
     } finally {
+        if (shouldResetBatchForm) {
+            resetBatchImportForm();
+        }
         submitButton.disabled = false;
         submitButton.textContent = '批量导入';
     }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -220,7 +220,18 @@
                             <button type="button" id="chooseJsonFileBtn" class="btn btn-primary">选择 JSON 文件</button>
                             <div class="json-import-file-hint" id="jsonImportFileName">支持单对象、对象数组，或 {"teams": [...]} 格式</div>
                         </div>
-                        <textarea name="batchContent" style="display:none"></textarea>
+                        <div class="batch-token-input-box">
+                            <label for="batchAccessTokens" class="batch-token-input-title">或直接粘贴 Access Token</label>
+                            <textarea id="batchAccessTokens" name="batchContent" class="form-control batch-token-textarea" rows="8" placeholder="每行粘贴一个 Access Token (AT)，系统会自动解析账号信息
+
+eyJ...
+eyJ...
+eyJ..."></textarea>
+                            <small class="form-text">一行一个 AT，粘贴后点击下方“批量导入”即可自动解析邮箱与账号信息。</small>
+                        </div>
+                        <div class="form-actions" style="margin-bottom: 1rem;">
+                            <button type="submit" class="btn btn-primary">批量导入</button>
+                        </div>
                         <div id="batchProgressContainer" style="display: none; margin-bottom: 1.5rem;">
                             <div class="progress-info"
                                 style="display: flex; justify-content: space-between; margin-bottom: 0.5rem; font-size: 0.875rem;">


### PR DESCRIPTION
### Motivation
- Provide a convenient way to bulk-import teams by pasting multiple Access Tokens and improve the import UX by resetting the form after successful imports.
- Fix layout issues so the main content and sidebar align properly and behave predictably across screen sizes.
- Improve mobile sidebar sizing and theme-specific sidebar backgrounds for better visual consistency.

### Description
- Added a pasteable batch token input UI by replacing the hidden textarea with a labeled `#batchAccessTokens` textarea and a submit button inside `#batchImportForm` in `base.html`.
- Implemented `resetBatchImportForm()` in `main.js` to clear the `#batchImportForm` inputs and file name hint and call it when the `importTeamModal` closes or when a batch import finishes with zero failures, wired via a `shouldResetBatchForm` flag.
- Updated layout and responsive CSS in `style.css`, including `.main-container` alignment, `.sidebar` and `.main-content` sizing (`flex` and `width` adjustments), new styles for the batch input (`.batch-token-input-*`), and mobile improvements such as `--mobile-sidebar-width`, theme-specific sidebar backgrounds, and overlay handling.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb5a2cd80483308c5da0740f021961)