### PR TITLE
Fix admin dashboard layout nesting

### DIFF
--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -352,7 +352,6 @@
     <button onclick="showModal('importTeamModal')" class="btn btn-primary">立即导入</button>
 </div>
 {% endif %}
-</div>
 
 <!-- 编辑 Team 模态框 -->
 <div id="editTeamModal" class="modal-overlay">


### PR DESCRIPTION
### Motivation
- Fix a layout bug where the admin dashboard right-side content could drop below the sidebar because of a stray closing `</div>` that prematurely closed the main content area.

### Description
- Remove the extra `</div>` from `app/templates/admin/index.html` so the dashboard content and subsequent modal markup remain correctly nested inside the main content container.

### Testing
- Ran a small `python` script to count occurrences of `<div` and `</div>` in `app/templates/admin/index.html` and confirmed the open/close counts are balanced after the change, which passed. 
- Inspected the template snippet with `nl -ba app/templates/admin/index.html | sed -n '344,360p'` to confirm the stray closing tag was removed and surrounding structure is intact, which passed.
- Manually reviewed the file diff to ensure the change is a single deletion of the stray closing tag and no other markup was modified, which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb6aa7086c83309386d7f3df7c8828)