### PR TITLE
Refactor admin layout: unify container classes and fix HTML structure

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -265,17 +265,12 @@ body.admin-theme .toast {
     letter-spacing: -0.025em;
 }
 
-.app-layout {
+.main-container {
     display: flex;
     align-items: flex-start;
     flex-wrap: nowrap;
     max-width: 1440px;
     margin: 0 auto;
-}
-
-.main-container {
-    flex: 1;
-    min-width: 0;
 }
 
 .sidebar {
@@ -328,7 +323,6 @@ body.admin-theme .toast {
 
 .main-content {
     flex: 1 1 auto;
-    width: calc(100% - 260px);
     min-width: 0;
     /* Allow content to shrink and trigger scrolling */
     padding: 2rem 3rem;

--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -352,7 +352,6 @@
     <button onclick="showModal('importTeamModal')" class="btn btn-primary">立即导入</button>
 </div>
 {% endif %}
-</div>
 
 <!-- 编辑 Team 模态框 -->
 <div id="editTeamModal" class="modal-overlay">

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -54,7 +54,7 @@
     <div id="sidebarOverlay" class="sidebar-overlay" onclick="toggleSidebar()"></div>
 
     <!-- 主容器 -->
-    <div class="app-layout">
+    <div class="main-container">
         <!-- 侧边栏 -->
         <aside class="sidebar" id="adminSidebar">
             <ul class="sidebar-menu">
@@ -97,12 +97,10 @@
             </ul>
         </aside>
 
-        <div class="main-container">
-            <!-- 主内容区 -->
-            <main class="main-content">
-                {% block content %}{% endblock %}
-            </main>
-        </div>
+        <!-- 主内容区 -->
+        <main class="main-content">
+            {% block content %}{% endblock %}
+        </main>
     </div>
     {% else %}
     <!-- 未登录时的内容 -->


### PR DESCRIPTION
### Motivation
- Fix inconsistent container class usage and duplicated wrappers that caused layout and overflow issues in the admin UI.
- Ensure the sidebar and main content flex and respond correctly without relying on a hard `calc()` width.

### Description
- Rename CSS selector ` .app-layout` to ` .main-container` and remove a duplicate ` .main-container` block to consolidate layout styles.
- Remove the fixed `width: calc(100% - 260px)` from `.main-content` so the content area can flex naturally.
- Update `base.html` to use the unified `main-container` and simplify the DOM by removing an extra wrapper around the main content.
- Remove an extraneous closing `</div>` in `admin/index.html` to correct HTML structure for modals.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb6aa7086c83309386d7f3df7c8828)