### PR TITLE
Fix modal background layering for team edit

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -177,6 +177,28 @@ body.admin-theme .page-header {
     z-index: 1;
 }
 
+body.modal-open .navbar,
+body.modal-open .sidebar,
+body.modal-open .main-container,
+body.modal-open .footer {
+    pointer-events: none;
+    user-select: none;
+}
+
+body.modal-open .navbar,
+body.modal-open .sidebar,
+body.modal-open .main-container,
+body.modal-open .footer,
+body.modal-open .sidebar-overlay {
+    filter: blur(3px);
+    opacity: 0.28;
+    transition: opacity var(--transition-base), filter var(--transition-base);
+}
+
+body.modal-open .modal-overlay.show {
+    z-index: 2000;
+}
+
 body.admin-theme .menu-item a:hover,
 body.admin-theme .data-table tbody tr:hover td,
 body.admin-theme .dropdown-item:hover {
@@ -1411,13 +1433,13 @@ body.admin-theme .toast {
     }
 
     .modal-overlay {
-        top: 64px;
+        top: 0;
         padding: 1.5rem 2rem 2rem;
     }
 
     .modal {
-        margin: 0 auto;
-        max-height: calc(100vh - 64px - 3.5rem);
+        margin: auto;
+        max-height: calc(100vh - 3.5rem);
     }
 }
 

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -297,6 +297,12 @@ function showModal(modalId) {
     if (modal) {
         modal.classList.add('show');
         document.body.style.overflow = 'hidden'; // 防止背景滚动
+        document.body.classList.add('modal-open');
+
+        const sidebar = document.getElementById('adminSidebar');
+        const overlay = document.getElementById('sidebarOverlay');
+        if (sidebar) sidebar.classList.remove('open');
+        if (overlay) overlay.classList.remove('show');
 
         if (modalId === 'importTeamModal') {
             setSingleImportMode('quick');
@@ -325,7 +331,12 @@ function hideModal(modalId) {
     const modal = document.getElementById(modalId);
     if (modal) {
         modal.classList.remove('show');
-        document.body.style.overflow = '';
+
+        const openModal = document.querySelector('.modal-overlay.show');
+        if (!openModal) {
+            document.body.style.overflow = '';
+            document.body.classList.remove('modal-open');
+        }
 
         if (modalId === 'importTeamModal') {
             resetBatchImportForm();


### PR DESCRIPTION
### Motivation
- When opening the edit Team modal the sticky navbar, sidebar and footer remained visible and interactive which interferes with the modal focus.
- The desktop modal backdrop started below the sticky navbar so the overlay did not cover the full viewport and the header leaked through.

### Description
- Add `body.modal-open` CSS rules in `app/static/css/style.css` to dim (`filter: blur(3px); opacity: 0.28`) and disable pointer events for `.navbar`, `.sidebar`, `.main-container`, `.footer`, and `.sidebar-overlay` while a modal is open.
- Change the desktop `.modal-overlay` positioning to `top: 0` and make `.modal-overlay.show` higher z-index in `app/static/css/style.css` so the backdrop covers the full viewport and the modal stays above other UI.
- Update `showModal(modalId)` in `app/static/js/main.js` to add `body.modal-open` and to close any mobile sidebar/overlay when opening a modal, and update `hideModal(modalId)` to remove `body.modal-open` only when no other modal is open.

### Testing
- Ran `python -m compileall app` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb751ae6cc8330a12e4348b2f3a0d9)