### PR TITLE
Fix modal behavior: disable background UI, adjust overlay/spacing, and mount modals to body

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -177,6 +177,26 @@ body.admin-theme .page-header {
     z-index: 1;
 }
 
+body.modal-open .navbar,
+body.modal-open .sidebar,
+body.modal-open .footer,
+body.modal-open .sidebar-overlay {
+    pointer-events: none;
+    user-select: none;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity var(--transition-base), visibility var(--transition-base);
+}
+
+body.modal-open .main-container {
+    pointer-events: none;
+    user-select: none;
+}
+
+body.modal-open .modal-overlay.show {
+    z-index: 2000;
+}
+
 body.admin-theme .menu-item a:hover,
 body.admin-theme .data-table tbody tr:hover td,
 body.admin-theme .dropdown-item:hover {
@@ -1411,13 +1431,13 @@ body.admin-theme .toast {
     }
 
     .modal-overlay {
-        top: 64px;
+        top: 0;
         padding: 1.5rem 2rem 2rem;
     }
 
     .modal {
-        margin: 0 auto;
-        max-height: calc(100vh - 64px - 3.5rem);
+        margin: auto;
+        max-height: calc(100vh - 3.5rem);
     }
 }
 

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -297,6 +297,12 @@ function showModal(modalId) {
     if (modal) {
         modal.classList.add('show');
         document.body.style.overflow = 'hidden'; // 防止背景滚动
+        document.body.classList.add('modal-open');
+
+        const sidebar = document.getElementById('adminSidebar');
+        const overlay = document.getElementById('sidebarOverlay');
+        if (sidebar) sidebar.classList.remove('open');
+        if (overlay) overlay.classList.remove('show');
 
         if (modalId === 'importTeamModal') {
             setSingleImportMode('quick');
@@ -325,7 +331,12 @@ function hideModal(modalId) {
     const modal = document.getElementById(modalId);
     if (modal) {
         modal.classList.remove('show');
-        document.body.style.overflow = '';
+
+        const openModal = document.querySelector('.modal-overlay.show');
+        if (!openModal) {
+            document.body.style.overflow = '';
+            document.body.classList.remove('modal-open');
+        }
 
         if (modalId === 'importTeamModal') {
             resetBatchImportForm();

--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -454,6 +454,11 @@
 {% block extra_js %}
 <script>
     document.addEventListener('DOMContentLoaded', () => {
+        const editTeamModal = document.getElementById('editTeamModal');
+        if (editTeamModal && editTeamModal.parentElement !== document.body) {
+            document.body.appendChild(editTeamModal);
+        }
+
         // Init Column Toggler
         initColumnToggler('.data-table', 'team_list_columns');
 


### PR DESCRIPTION
### Motivation
- Prevent background navigation and interactions while modals are open and ensure consistent overlay stacking and scrolling behavior.
- Ensure modals are positioned and sized correctly across viewport / admin layout so they do not get clipped by sticky header/sidebar offsets.
- Guarantee specific modals (like the edit modal) are direct children of `body` so overlay and focus behaviors work reliably.

### Description
- Added `.modal-open` CSS rules to disable pointer events and selection on `.navbar`, `.sidebar`, `.footer`, and `.sidebar-overlay`, hide them visually while a modal is open, and applied transitions; also added `pointer-events: none` to `.main-container` when modal is open and raised `.modal-overlay.show` z-index.
- Adjusted layout rules: changed `.modal-overlay` `top` to `0`, and updated `.modal` margin and `max-height` calculations to avoid clipping by header offsets.
- Updated JavaScript modal logic in `main.js` so `showModal` adds `document.body.classList.add('modal-open')`, closes the admin sidebar/overlay when opening a modal, and `hideModal` only clears `overflow` and removes `modal-open` when no other visible modal overlays remain.
- Ensured `editTeamModal` is appended to `document.body` in `admin/index.html` on DOM ready so the modal is a top-level child and overlay stacking behaves correctly.

### Testing
- Ran backend test suite with `pytest` and all tests passed.
- Ran frontend tests with `npm test` and JavaScript/CSS-related integration checks and they passed.
- Ran linters with `npm run lint` and no errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb751ae6cc8330a12e4348b2f3a0d9)