### PR TITLE
Prevent background interaction while modals are open and fix modal/sidebar stacking

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -177,6 +177,29 @@ body.admin-theme .page-header {
     z-index: 1;
 }
 
+body.modal-open .navbar,
+body.modal-open .sidebar,
+body.modal-open .footer {
+    pointer-events: none;
+    user-select: none;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity var(--transition-base), visibility var(--transition-base);
+}
+
+body.modal-open .main-container {
+    pointer-events: none;
+    user-select: none;
+}
+
+body.modal-open .sidebar-overlay {
+    display: none !important;
+}
+
+body.modal-open .modal-overlay.show {
+    z-index: 2000;
+}
+
 body.admin-theme .menu-item a:hover,
 body.admin-theme .data-table tbody tr:hover td,
 body.admin-theme .dropdown-item:hover {
@@ -1411,13 +1434,13 @@ body.admin-theme .toast {
     }
 
     .modal-overlay {
-        top: 64px;
+        top: 0;
         padding: 1.5rem 2rem 2rem;
     }
 
     .modal {
-        margin: 0 auto;
-        max-height: calc(100vh - 64px - 3.5rem);
+        margin: auto;
+        max-height: calc(100vh - 3.5rem);
     }
 }
 
@@ -1511,11 +1534,12 @@ body.admin-theme .toast {
     .sidebar-overlay {
         position: fixed;
         top: 64px;
-        left: var(--mobile-sidebar-width);
+        left: 0;
         right: 0;
         bottom: 0;
         background-color: rgba(15, 23, 42, 0.4);
-        backdrop-filter: blur(4px);
+        backdrop-filter: none;
+        -webkit-backdrop-filter: none;
         z-index: 1090;
         opacity: 0;
         pointer-events: none;

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -297,6 +297,12 @@ function showModal(modalId) {
     if (modal) {
         modal.classList.add('show');
         document.body.style.overflow = 'hidden'; // 防止背景滚动
+        document.body.classList.add('modal-open');
+
+        const sidebar = document.getElementById('adminSidebar');
+        const overlay = document.getElementById('sidebarOverlay');
+        if (sidebar) sidebar.classList.remove('open');
+        if (overlay) overlay.classList.remove('show');
 
         if (modalId === 'importTeamModal') {
             setSingleImportMode('quick');
@@ -325,7 +331,12 @@ function hideModal(modalId) {
     const modal = document.getElementById(modalId);
     if (modal) {
         modal.classList.remove('show');
-        document.body.style.overflow = '';
+
+        const openModal = document.querySelector('.modal-overlay.show');
+        if (!openModal) {
+            document.body.style.overflow = '';
+            document.body.classList.remove('modal-open');
+        }
 
         if (modalId === 'importTeamModal') {
             resetBatchImportForm();

--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -454,6 +454,11 @@
 {% block extra_js %}
 <script>
     document.addEventListener('DOMContentLoaded', () => {
+        const editTeamModal = document.getElementById('editTeamModal');
+        if (editTeamModal && editTeamModal.parentElement !== document.body) {
+            document.body.appendChild(editTeamModal);
+        }
+
         // Init Column Toggler
         initColumnToggler('.data-table', 'team_list_columns');
 


### PR DESCRIPTION
### Motivation
- Prevent background UI from being clickable or visible when a modal is open to avoid accidental interactions and visual glitches.  
- Ensure modal overlays and modals stack correctly above other layout elements and work on both desktop and mobile.  
- Fix positioning/z-index issues by ensuring the edit team modal is a direct child of `document.body` so it displays above other components.

### Description
- Add `.modal-open` body rules to disable pointer events, selection, and visibility for `.navbar`, `.sidebar`, and `.footer`, and hide the `.sidebar-overlay` while a modal is open.  
- Increase `.modal-overlay.show` stacking with `z-index: 2000`, set `.modal-overlay` `top: 0`, and relax modal margin/max-height to avoid clipping on smaller screens.  
- Adjust mobile sidebar overlay to `left: 0`, remove its backdrop blur for performance and compatibility, and ensure appropriate show/hide transitions.  
- Update JS modal helpers: `showModal` adds `modal-open`, closes the sidebar and hides its overlay when opening a modal, and `hideModal` only removes `modal-open` and restores `body.style.overflow` when no other modal overlay remains.  
- Ensure the `editTeamModal` element is appended to `document.body` on `DOMContentLoaded` to avoid stacking/positioning issues.

### Testing
- Ran the existing automated test suite with `pytest`, and all tests passed.  
- Ran lint/static checks (`flake8`/CSS linter) and no new issues were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb751ae6cc8330a12e4348b2f3a0d9)