### PR TITLE
Fix modal overlay behavior and responsive sidebar mounting

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -177,6 +177,29 @@ body.admin-theme .page-header {
     z-index: 1;
 }
 
+body.modal-open .navbar,
+body.modal-open .sidebar,
+body.modal-open .footer {
+    pointer-events: none;
+    user-select: none;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity var(--transition-base), visibility var(--transition-base);
+}
+
+body.modal-open .main-container {
+    pointer-events: none;
+    user-select: none;
+}
+
+body.modal-open .sidebar-overlay {
+    display: none !important;
+}
+
+body.modal-open .modal-overlay.show {
+    z-index: 2000;
+}
+
 body.admin-theme .menu-item a:hover,
 body.admin-theme .data-table tbody tr:hover td,
 body.admin-theme .dropdown-item:hover {
@@ -1411,13 +1434,13 @@ body.admin-theme .toast {
     }
 
     .modal-overlay {
-        top: 64px;
+        top: 0;
         padding: 1.5rem 2rem 2rem;
     }
 
     .modal {
-        margin: 0 auto;
-        max-height: calc(100vh - 64px - 3.5rem);
+        margin: auto;
+        max-height: calc(100vh - 3.5rem);
     }
 }
 
@@ -1511,11 +1534,12 @@ body.admin-theme .toast {
     .sidebar-overlay {
         position: fixed;
         top: 64px;
-        left: var(--mobile-sidebar-width);
+        left: 0;
         right: 0;
         bottom: 0;
         background-color: rgba(15, 23, 42, 0.4);
-        backdrop-filter: blur(4px);
+        backdrop-filter: none;
+        -webkit-backdrop-filter: none;
         z-index: 1090;
         opacity: 0;
         pointer-events: none;

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -210,6 +210,27 @@ function setSingleImportMode(mode = 'quick') {
     manualSection.style.display = isManual ? 'block' : 'none';
 }
 
+function syncResponsiveSidebarMount() {
+    const sidebar = document.getElementById('adminSidebar');
+    const overlay = document.getElementById('sidebarOverlay');
+    const mainContainer = document.querySelector('.main-container');
+    const mainContent = document.querySelector('.main-content');
+    if (!sidebar || !overlay || !mainContainer || !mainContent) return;
+
+    const isMobileLayout = window.matchMedia('(max-width: 768px)').matches;
+
+    if (isMobileLayout) {
+        if (sidebar.parentElement !== document.body) {
+            overlay.insertAdjacentElement('afterend', sidebar);
+        }
+        return;
+    }
+
+    if (sidebar.parentElement !== mainContainer) {
+        mainContainer.insertBefore(sidebar, mainContent);
+    }
+}
+
 // 页面加载完成后执行
 document.addEventListener('DOMContentLoaded', function () {
     // 检查认证状态
@@ -217,6 +238,8 @@ document.addEventListener('DOMContentLoaded', function () {
 
     cleanupLegacyThemeSettingsSection();
     initThemeSwitcher();
+    syncResponsiveSidebarMount();
+    window.addEventListener('resize', syncResponsiveSidebarMount);
 
     // OAuth 一键导入按钮绑定（避免仅依赖内联 onclick）
     const btnOneClickToken = document.getElementById('btnOneClickToken');
@@ -297,6 +320,12 @@ function showModal(modalId) {
     if (modal) {
         modal.classList.add('show');
         document.body.style.overflow = 'hidden'; // 防止背景滚动
+        document.body.classList.add('modal-open');
+
+        const sidebar = document.getElementById('adminSidebar');
+        const overlay = document.getElementById('sidebarOverlay');
+        if (sidebar) sidebar.classList.remove('open');
+        if (overlay) overlay.classList.remove('show');
 
         if (modalId === 'importTeamModal') {
             setSingleImportMode('quick');
@@ -325,7 +354,12 @@ function hideModal(modalId) {
     const modal = document.getElementById(modalId);
     if (modal) {
         modal.classList.remove('show');
-        document.body.style.overflow = '';
+
+        const openModal = document.querySelector('.modal-overlay.show');
+        if (!openModal) {
+            document.body.style.overflow = '';
+            document.body.classList.remove('modal-open');
+        }
 
         if (modalId === 'importTeamModal') {
             resetBatchImportForm();

--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -454,6 +454,11 @@
 {% block extra_js %}
 <script>
     document.addEventListener('DOMContentLoaded', () => {
+        const editTeamModal = document.getElementById('editTeamModal');
+        if (editTeamModal && editTeamModal.parentElement !== document.body) {
+            document.body.appendChild(editTeamModal);
+        }
+
         // Init Column Toggler
         initColumnToggler('.data-table', 'team_list_columns');
 


### PR DESCRIPTION
### Motivation
- Prevent background chrome (navbar, sidebar, footer) from being interactive or visible when modals are open to avoid visual and interaction glitches.
- Ensure the sidebar is mounted in the correct container depending on viewport size so mobile and desktop layouts behave consistently.
- Tidy mobile overlay/backdrop positioning and z-index so modal overlays appear above other UI layers.

### Description
- Add CSS rules for `body.modal-open` to hide and disable interactions with the navbar, sidebar, and footer, and adjust `.modal-overlay` stacking with `z-index: 2000`.
- Adjust layout spacing by changing `.modal-overlay` `top` to `0` and update `.modal` `margin` and `max-height` calculations.
- Change mobile `.sidebar-overlay` positioning to `left: 0`, remove backdrop blur on mobile, and ensure sidebar overlay z-index and visibility transitions behave correctly.
- Add `syncResponsiveSidebarMount()` in `main.js` to move the sidebar between `document.body` and `.main-container` based on the `(max-width: 768px)` media query, hook it on `DOMContentLoaded` and `resize`, and update `showModal()`/`hideModal()` to manage `body.classList` `modal-open` and close the sidebar when showing a modal.
- Ensure `editTeamModal` is appended to `document.body` on load in `admin/index.html` so modals are mounted at the top level.

### Testing
- Ran frontend linter with `npm run lint` and it passed without errors.
- Executed the test suite with `pytest` and all existing tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb751ae6cc8330a12e4348b2f3a0d9)