### PR TITLE
Improve startup import resolution, error handling, warranty queries, and UI button behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ python init_db.py
 python -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8008
 
 # 或者直接运行
-python app/main.py
+python -m app.main
 ```
 
 ### 7. 访问应用

--- a/app/main.py
+++ b/app/main.py
@@ -2,13 +2,18 @@
 GPT Team 管理和兑换码自动邀请系统
 FastAPI 应用入口文件
 """
+import sys
+from pathlib import Path
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
 from fastapi import FastAPI, Request
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, FileResponse
 from starlette.middleware.sessions import SessionMiddleware
 import logging
-from pathlib import Path
 from datetime import datetime
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
@@ -384,8 +389,8 @@ async def favicon():
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run(
-        "main:app",
+        "app.main:app",
         host=settings.app_host,
         port=settings.app_port,
-        reload=settings.debug
+        reload=settings.debug and __package__ not in {None, ""}
     )

--- a/app/routes/user.py
+++ b/app/routes/user.py
@@ -59,8 +59,8 @@ async def redeem_page(
         )
 
     except Exception as e:
-        logger.error(f"渲染兑换页面失败: {e}")
+        logger.exception("渲染兑换页面失败")
         return HTMLResponse(
-            content=f"<h1>页面加载失败</h1><p>{str(e)}</p>",
+            content="<h1>页面加载失败</h1><p>系统暂时不可用，请稍后重试。</p>",
             status_code=500
         )

--- a/app/routes/warranty.py
+++ b/app/routes/warranty.py
@@ -2,7 +2,7 @@
 质保相关路由
 处理用户质保查询请求
 """
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, EmailStr
 from typing import Optional
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -78,9 +78,15 @@ async def check_warranty(
         )
         
         if not result["success"]:
+            error_message = result.get("error", "查询失败")
+            status_code = 500
+            if "查询太频繁" in error_message:
+                status_code = 429
+            elif "必须提供" in error_message or "未找到" in error_message:
+                status_code = 400
             raise HTTPException(
-                status_code=500,
-                detail=result.get("error", "查询失败")
+                status_code=status_code,
+                detail=error_message
             )
         
         return WarrantyCheckResponse(

--- a/app/services/warranty.py
+++ b/app/services/warranty.py
@@ -142,11 +142,7 @@ class WarrantyService:
                     .order_by(RedemptionRecord.redeemed_at.desc())
                 )
                 result = await db_session.execute(stmt)
-                first_record = result.first()
-                if first_record:
-                    records_data = [first_record]
-                else:
-                    records_data = []
+                records_data = result.all()
 
                 # 如果没有记录，可能是码还没被使用或不存在
                 if not records_data:

--- a/app/static/js/redeem.js
+++ b/app/static/js/redeem.js
@@ -232,7 +232,7 @@ function renderTeamsList() {
     availableTeams.forEach(team => {
         const teamCard = document.createElement('div');
         teamCard.className = 'team-card';
-        teamCard.onclick = () => selectTeam(team.id);
+        teamCard.onclick = () => selectTeam(team.id, teamCard);
 
         const planBadge = team.subscription_plan === 'Plus' ? 'badge-plus' : 'badge-pro';
 
@@ -261,14 +261,16 @@ function renderTeamsList() {
 }
 
 // 选择Team
-function selectTeam(teamId) {
+function selectTeam(teamId, teamCard) {
     selectedTeamId = teamId;
 
     // 更新UI
     document.querySelectorAll('.team-card').forEach(card => {
         card.classList.remove('selected');
     });
-    event.currentTarget.classList.add('selected');
+    if (teamCard) {
+        teamCard.classList.add('selected');
+    }
 
     // 立即确认兑换
     confirmRedeem(teamId);
@@ -602,7 +604,7 @@ function showWarrantyResult(data) {
                                              <span>${escapeHtml(record.team_name || '未知 Team')}</span>
                                              <span>${teamStatusBadge}</span>
                                              ${(record.has_warranty && record.warranty_valid && record.team_status === 'banned') ? `
-                                             <button onclick="oneClickReplace('${escapeHtml(record.code)}', '${escapeHtml(record.email || currentEmail)}')" class="btn btn-xs btn-primary" style="padding: 2px 8px; font-size: 0.75rem; height: auto; min-height: 0;">
+                                             <button onclick="oneClickReplace('${escapeHtml(record.code)}', '${escapeHtml(record.email || currentEmail)}', this)" class="btn btn-xs btn-primary" style="padding: 2px 8px; font-size: 0.75rem; height: auto; min-height: 0;">
                                                  一键换车
                                              </button>
                                              ` : ''}
@@ -632,7 +634,7 @@ function showWarrantyResult(data) {
                                              </div>
                                          </div>
                                          ${(!record.device_code_auth_enabled && record.team_status !== 'banned' && record.team_status !== 'expired') ? `
-                                         <button onclick="enableUserDeviceAuth(${record.team_id}, '${escapeHtml(record.code)}', '${escapeHtml(record.email)}')" class="btn btn-xs btn-primary" style="padding: 4px 10px; font-size: 0.75rem; height: auto;">
+                                         <button onclick="enableUserDeviceAuth(${record.team_id}, '${escapeHtml(record.code)}', '${escapeHtml(record.email)}', this)" class="btn btn-xs btn-primary" style="padding: 4px 10px; font-size: 0.75rem; height: auto;">
                                              一键开启
                                          </button>
                                          ` : ''}
@@ -700,7 +702,7 @@ function copyWarrantyCode(code) {
 }
 
 // 一键换车
-async function oneClickReplace(code, email) {
+async function oneClickReplace(code, email, btn) {
     if (!code || !email) {
         showToast('无法获取完整信息，请手动重试', 'error');
         return;
@@ -716,12 +718,13 @@ async function oneClickReplace(code, email) {
     if (emailInput) emailInput.value = email;
     if (codeInput) codeInput.value = code;
 
-    const btn = event.currentTarget;
-    const originalContent = btn.innerHTML;
+    const originalContent = btn ? btn.innerHTML : "";
 
     // 禁用所有按钮防止重复提交
-    btn.disabled = true;
-    btn.innerHTML = '<i data-lucide="loader" class="spinning"></i> 处理中...';
+    if (btn) {
+        btn.disabled = true;
+        btn.innerHTML = '<i data-lucide="loader" class="spinning"></i> 处理中...';
+    }
     if (window.lucide) lucide.createIcons();
 
     showToast('正在为您尝试自动兑换...', 'info');
@@ -743,15 +746,16 @@ async function oneClickReplace(code, email) {
 }
 
 // 用户一键开启设备身份验证
-async function enableUserDeviceAuth(teamId, code, email) {
+async function enableUserDeviceAuth(teamId, code, email, btn) {
     if (!confirm('确定要在该 Team 中开启设备代码身份验证吗？')) {
         return;
     }
 
-    const btn = event.currentTarget;
-    const originalContent = btn.innerHTML;
-    btn.disabled = true;
-    btn.innerHTML = '<i data-lucide="loader" class="spinning"></i> 开启中...';
+    const originalContent = btn ? btn.innerHTML : "";
+    if (btn) {
+        btn.disabled = true;
+        btn.innerHTML = '<i data-lucide="loader" class="spinning"></i> 开启中...';
+    }
     if (window.lucide) lucide.createIcons();
 
     try {

--- a/app/templates/admin/records/index.html
+++ b/app/templates/admin/records/index.html
@@ -127,7 +127,7 @@
                     </td>
                     <td style="text-align: right;">{{ record.redeemed_at }}</td>
                     <td style="text-align: right;">
-                        <button onclick="withdrawRecord('{{ record.id }}', '{{ record.email }}')"
+                        <button onclick="withdrawRecord('{{ record.id }}', '{{ record.email }}', this)"
                             class="btn btn-sm btn-danger" title="撤回邀请并恢复兑换码">
                             <i data-lucide="undo-2" style="width: 14px; height: 14px;"></i> 撤回
                         </button>
@@ -264,17 +264,18 @@
 
 {% block extra_js %}
 <script>
-    async function withdrawRecord(recordId, email) {
+    async function withdrawRecord(recordId, email, btn) {
         if (!confirm(`确定要撤回针对 ${email} 的兑换记录吗？\n\n这将执行以下操作：\n1. 在 ChatGPT Team 中撤回邀请或删除成员\n2. 按剩余使用记录重建兑换码状态\n3. 删除此条使用记录`)) {
             return;
         }
 
+        const originalContent = btn ? btn.innerHTML : "";
+
         try {
-            // 获取当前点击的按钮
-            const btn = event.currentTarget;
-            const originalContent = btn.innerHTML;
-            btn.disabled = true;
-            btn.innerHTML = '<i data-lucide="loader-2" class="spin" style="width: 14px; height: 14px;"></i> 处理中...';
+            if (btn) {
+                btn.disabled = true;
+                btn.innerHTML = '<i data-lucide="loader-2" class="spin" style="width: 14px; height: 14px;"></i> 处理中...';
+            }
             lucide.createIcons();
 
             const response = await fetch(`/admin/records/${recordId}/withdraw`, {
@@ -292,16 +293,20 @@
                 setTimeout(() => location.reload(), 1000);
             } else {
                 showToast(result.error || '撤回失败', 'error');
-                btn.disabled = false;
-                btn.innerHTML = originalContent;
-                lucide.createIcons();
+                if (btn) {
+                    btn.disabled = false;
+                    btn.innerHTML = originalContent;
+                    lucide.createIcons();
+                }
             }
         } catch (error) {
             console.error('撤回失败:', error);
             showToast('请求失败，请检查网络或日志', 'error');
             // 如果出错，尝试恢复按钮
-            if (event && event.currentTarget) {
-                event.currentTarget.disabled = false;
+            if (btn) {
+                btn.disabled = false;
+                btn.innerHTML = originalContent;
+                lucide.createIcons();
             }
         }
     }


### PR DESCRIPTION
### Motivation
- Ensure the application can be executed both as a module and a script and avoid import path issues when running via `python -m` or directly. 
- Improve robustness and clarity of server-side error logging and HTTP status mapping for warranty queries. 
- Fix UI button interactions to avoid relying on global `event` and to reliably show loading states and restore buttons after async operations.

### Description
- Update `README.md` to recommend `python -m app.main` as a safe way to start the application. 
- Modify `app/main.py` to insert the project root into `sys.path` when `__package__` is unset and adjust `uvicorn.run` target to `app.main:app` and refine the `reload` condition. 
- Improve error handling in `app/routes/user.py` by using `logger.exception` for stack traces and returning a generic 500 HTML message instead of exposing raw exception text. 
- Enhance warranty route `app/routes/warranty.py` to map service error messages to appropriate HTTP status codes (e.g., `429` for rate limits and `400` for missing/not-found cases) and import `status`. 
- Change warranty service `app/services/warranty.py` to collect all redemption records for a code (`result.all()`) instead of only the first match. 
- Refactor frontend JS `app/static/js/redeem.js` to pass button/element references into handlers, avoid using `event.currentTarget`, and safely toggle disabled/spinner states in `selectTeam`, `oneClickReplace`, and `enableUserDeviceAuth`. 
- Update admin records template `app/templates/admin/records/index.html` to accept a `btn` parameter in `withdrawRecord` and manage the button state reliably when performing withdrawals and on error.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb932391c4833093e0a3c2b4055ada)