### PR TITLE
Fix toast/modal stacking: mount overlays to body and raise toast z-index

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1288,7 +1288,7 @@ body.admin-theme .toast {
     transform: translateY(calc(100% + 20px));
     opacity: 0;
     transition: transform var(--transition-base), opacity var(--transition-fast);
-    z-index: 1200;
+    z-index: 4000;
     border: 1px solid var(--border-base);
 }
 

--- a/app/static/css/user.css
+++ b/app/static/css/user.css
@@ -505,7 +505,7 @@ body {
   position: fixed;
   right: 18px;
   top: 18px;
-  z-index: 50;
+  z-index: 4000;
   display: none;
   align-items: center;
   gap: 8px;

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -141,6 +141,15 @@ function showToast(message, type = 'info') {
     }, 3000);
 }
 
+function mountGlobalOverlayNodes() {
+    const nodes = document.querySelectorAll('.modal-overlay, #toast');
+    nodes.forEach((node) => {
+        if (node && node.parentElement !== document.body) {
+            document.body.appendChild(node);
+        }
+    });
+}
+
 // 日期格式化函数
 function formatDateTime(dateString) {
     if (!dateString) return '-';
@@ -248,6 +257,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
     cleanupLegacyThemeSettingsSection();
     initThemeSwitcher();
+    mountGlobalOverlayNodes();
     syncResponsiveSidebarMount();
     window.addEventListener('resize', syncResponsiveSidebarMount);
 


### PR DESCRIPTION
### Motivation

- The toast/messages were rendered underneath modal overlays in pages like the "导入 Team" flow (after generating an authorization link), making prompts invisible to users.
- The root cause is CSS stacking context / DOM placement where `.modal-overlay` and `#toast` could be inside containers with lower stacking order, so toasts must be isolated and stacked above modals.

### Description

- Added `mountGlobalOverlayNodes()` in `app/static/js/main.js` and call it on `DOMContentLoaded` to ensure all `.modal-overlay` and the shared `#toast` element are moved under `document.body` (so they are outside local stacking contexts). (`app/static/js/main.js`)
- Increased `z-index` for admin toasts from `1200` to `4000` in `app/static/css/style.css` so toasts render above modal overlays. (`app/static/css/style.css`)
- Increased `z-index` for user-side toasts to `4000` in `app/static/css/user.css` to cover non-admin pages as well. (`app/static/css/user.css`)

### Testing

- Ran `python -m compileall app` and confirmed all Python modules compile successfully. (passed)
- Verified the produced diffs for `app/static/js/main.js`, `app/static/css/style.css`, and `app/static/css/user.css` to ensure the intended changes were applied. (passed)
- UI screenshot verification was not performed because no browser/screenshot tool was available in this environment; recommend a quick manual browser check for the import/generate-auth flow to confirm toasts now appear above modals. (skipped)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bcc09390d08320aa547475418f480f)