### PR TITLE
Reserve seats during redemption, sync Team state before invites, and fix toast/overlay z-index and mounting

### DIFF
--- a/app/services/redeem_flow.py
+++ b/app/services/redeem_flow.py
@@ -188,6 +188,7 @@ class RedeemFlowService:
         async with _code_locks[code]:
             for attempt in range(max_retries):
                 logger.info(f"兑换尝试 {attempt + 1}/{max_retries} (Code: {code}, Email: {email})")
+                seat_reserved = False
                 
                 try:
                     validate_result = await self.redemption_service.validate_code(code, db_session)
@@ -262,6 +263,12 @@ class RedeemFlowService:
                                 target_team.status = "full"
                                 raise Exception("该 Team 已满, 请选择其他 Team 尝试")
 
+                            # 预留一个席位，避免并发兑换把同一辆车超卖到 max_members 以上
+                            target_team.current_members += 1
+                            seat_reserved = True
+                            if target_team.current_members >= target_team.max_members:
+                                target_team.status = "full"
+
                             # 提取必要信息后立即提交，释放 DB 锁以进行耗时的 API 调用
                             account_id_to_use = target_team.account_id
                             team_email_to_use = target_team.email
@@ -303,17 +310,44 @@ class RedeemFlowService:
                                 err_str = str(err).lower()
                                 if any(kw in err_str for kw in ["already in workspace", "already in team", "already a member"]):
                                     logger.info(f"用户 {email} 已经在 Team {team_id_final} 中，视为兑换成功")
+                                    if seat_reserved and target_team.current_members > 0:
+                                        target_team.current_members -= 1
+                                    seat_reserved = False
                                 else:
                                     if any(kw in err_str for kw in ["maximum number of seats", "full", "no seats"]):
+                                        if seat_reserved:
+                                            target_team.current_members = max(
+                                                target_team.current_members - 1,
+                                                target_team.max_members
+                                            )
+                                            seat_reserved = False
                                         target_team.status = "full"
                                         await db_session.commit()
                                         raise Exception(f"该 Team 席位已满 (API Error: {err})")
-                                    await db_session.rollback()
+                                    if seat_reserved and target_team.current_members > 0:
+                                        target_team.current_members -= 1
+                                        seat_reserved = False
+                                    if target_team.current_members >= target_team.max_members:
+                                        target_team.status = "full"
+                                    elif target_team.expires_at and target_team.expires_at < get_now():
+                                        target_team.status = "expired"
+                                    else:
+                                        target_team.status = "active"
+                                    await db_session.commit()
                                     raise Exception(err)
 
                             invite_data = invite_res.get("data", {})
                             if "account_invites" in invite_data and not invite_data.get("account_invites"):
-                                await db_session.rollback()
+                                if seat_reserved and target_team.current_members > 0:
+                                    target_team.current_members -= 1
+                                    seat_reserved = False
+                                if target_team.current_members >= target_team.max_members:
+                                    target_team.status = "full"
+                                elif target_team.expires_at and target_team.expires_at < get_now():
+                                    target_team.status = "expired"
+                                else:
+                                    target_team.status = "active"
+                                await db_session.commit()
                                 raise Exception("Team账号受限: 官方拦截下发(响应空列表)，请检查账单/风控状态")
 
                             # 成功逻辑
@@ -384,9 +418,7 @@ class RedeemFlowService:
                                 is_warranty_redemption=(bool(rc and rc.has_warranty and (not rc.reusable_by_seat)))
                             )
                             db_session.add(record)
-                            target_team.current_members += 1
-                            if target_team.current_members >= target_team.max_members:
-                                target_team.status = "full"
+                            seat_reserved = False
                             
                             await db_session.commit()
                             
@@ -420,6 +452,30 @@ class RedeemFlowService:
                             await db_session.rollback()
                     except:
                         pass
+
+                    if seat_reserved and team_id_final:
+                        try:
+                            if db_session.in_transaction():
+                                await db_session.rollback()
+                            await db_session.begin()
+                            res = await db_session.execute(
+                                select(Team).where(Team.id == team_id_final).with_for_update()
+                            )
+                            reserved_team = res.scalar_one_or_none()
+                            if reserved_team and reserved_team.current_members > 0:
+                                reserved_team.current_members -= 1
+                                if reserved_team.current_members >= reserved_team.max_members:
+                                    reserved_team.status = "full"
+                                elif reserved_team.expires_at and reserved_team.expires_at < get_now():
+                                    reserved_team.status = "expired"
+                                else:
+                                    reserved_team.status = "active"
+                                await db_session.commit()
+                            else:
+                                await db_session.rollback()
+                        except Exception:
+                            if db_session.in_transaction():
+                                await db_session.rollback()
                     
                     # 判读是否中断重试
                     if any(kw in last_error for kw in ["不存在", "已使用", "已有正在使用", "质保已过期"]):

--- a/app/services/team.py
+++ b/app/services/team.py
@@ -1762,6 +1762,26 @@ class TeamService:
                     "该 Team 的登录凭证已过期，且自动刷新失败，请重新登录或重新导入",
                 )
 
+            sync_result = await self.sync_team_info(team_id, db_session)
+            if not sync_result.get("success"):
+                return self._admin_error(
+                    "team_sync_failed",
+                    sync_result.get("error") or "拉取 Team 最新成员状态失败，请稍后重试",
+                )
+
+            team = await db_session.get(Team, team_id)
+            if not team:
+                return self._admin_error("team_not_found", f"Team ID {team_id} 不存在")
+
+            if team.current_members >= team.max_members or team.status == "full":
+                team.status = "full"
+                await db_session.commit()
+                return {
+                    "success": False,
+                    "message": None,
+                    "error": "Team 已满,无法添加成员"
+                }
+
             # 4. 调用 ChatGPT API 发送邀请
             invite_result = await self.chatgpt_service.send_invite(
                 access_token,

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1288,7 +1288,7 @@ body.admin-theme .toast {
     transform: translateY(calc(100% + 20px));
     opacity: 0;
     transition: transform var(--transition-base), opacity var(--transition-fast);
-    z-index: 1200;
+    z-index: 4000;
     border: 1px solid var(--border-base);
 }
 

--- a/app/static/css/user.css
+++ b/app/static/css/user.css
@@ -505,7 +505,7 @@ body {
   position: fixed;
   right: 18px;
   top: 18px;
-  z-index: 50;
+  z-index: 4000;
   display: none;
   align-items: center;
   gap: 8px;

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -141,6 +141,15 @@ function showToast(message, type = 'info') {
     }, 3000);
 }
 
+function mountGlobalOverlayNodes() {
+    const nodes = document.querySelectorAll('.modal-overlay, #toast');
+    nodes.forEach((node) => {
+        if (node && node.parentElement !== document.body) {
+            document.body.appendChild(node);
+        }
+    });
+}
+
 // 日期格式化函数
 function formatDateTime(dateString) {
     if (!dateString) return '-';
@@ -248,6 +257,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
     cleanupLegacyThemeSettingsSection();
     initThemeSwitcher();
+    mountGlobalOverlayNodes();
     syncResponsiveSidebarMount();
     window.addEventListener('resize', syncResponsiveSidebarMount);
 


### PR DESCRIPTION
### Motivation

- Prevent race conditions where concurrent redemptions oversell a Team by reserving a seat before releasing DB locks and ensuring reserved seats are released on failure.
- Ensure Team state is fresh before attempting invites by syncing remote member counts and marking Teams as `full` when appropriate.
- Fix frontend overlay/notification layering so modals and toasts reliably display above other elements.

### Description

- In `redeem_flow.py` implement pre-reservation of a Team seat (`target_team.current_members += 1`) while holding the DB lock, track a `seat_reserved` flag, and restore/decrement the reservation on various failure paths including API invite errors and retry cleanup; adjust Team `status` updates accordingly.
- In `team.py` call `sync_team_info` and re-load the `Team` before sending invites, and mark/commit `status="full"` when `current_members >= max_members` to avoid sending invites for already-full Teams.
- In `app/static/css/style.css` and `app/static/css/user.css` increase toast `z-index` values to `4000` to bring notifications above overlays.
- In `app/static/js/main.js` add `mountGlobalOverlayNodes()` to move `.modal-overlay` and `#toast` nodes into `document.body` to ensure they are not clipped by container stacking contexts and call it on `DOMContentLoaded`.

### Testing

- No new automated tests were added for the seat reservation logic; the existing automated test suite was executed and there were no regressions detected in CI (existing tests passed).
- Lint/static checks were not changed; frontend changes were small and covered by manual inspection and browser smoke tests in the dev environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bcc09390d08320aa547475418f480f)