### PR TITLE
Fix welfare redemption record compatibility

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -319,6 +319,8 @@ async def generate_welfare_common_code(
             "welfare_common_code_used_count": "0",
             "welfare_common_code_generated_at": get_now().isoformat()
         })
+        await redemption_service.ensure_virtual_welfare_shadow_code(db, code)
+        await db.commit()
 
         return JSONResponse(content={"success": True, "code": code, "limit": total_seats, "used": 0, "remaining": total_seats})
     except Exception as e:

--- a/app/services/redeem_flow.py
+++ b/app/services/redeem_flow.py
@@ -487,6 +487,9 @@ class RedeemFlowService:
                                 # 同步更新缓存，避免下一次校验读取到旧值
                                 settings_service._cache["welfare_common_code_used_count"] = used_setting.value
 
+                            if is_virtual_welfare_code:
+                                await self.redemption_service.ensure_virtual_welfare_shadow_code(db_session, code)
+
                             record = RedemptionRecord(
                                 email=email,
                                 code=code,

--- a/app/services/redemption.py
+++ b/app/services/redemption.py
@@ -65,6 +65,44 @@ class RedemptionService:
         redemption_code.used_at = None
         redemption_code.warranty_expires_at = None
 
+
+    async def ensure_virtual_welfare_shadow_code(
+        self,
+        db_session: AsyncSession,
+        welfare_code: str
+    ) -> Optional[RedemptionCode]:
+        """
+        为当前福利通用码维护一条仅用于历史记录外键兼容的影子兑换码。
+        该记录不会参与真实校验逻辑，当前码的有效性始终以 settings 中的值为准。
+        """
+        normalized_code = str(welfare_code or "").strip()
+        if not normalized_code:
+            return None
+
+        result = await db_session.execute(
+            select(RedemptionCode).where(RedemptionCode.code == normalized_code)
+        )
+        shadow_code = result.scalar_one_or_none()
+
+        if shadow_code:
+            shadow_code.pool_type = "welfare"
+            shadow_code.reusable_by_seat = True
+            shadow_code.status = shadow_code.status or "expired"
+            shadow_code.has_warranty = False
+            shadow_code.warranty_days = 0
+            return shadow_code
+
+        shadow_code = RedemptionCode(
+            code=normalized_code,
+            status="expired",
+            has_warranty=False,
+            warranty_days=0,
+            pool_type="welfare",
+            reusable_by_seat=True,
+        )
+        db_session.add(shadow_code)
+        return shadow_code
+
     async def get_virtual_welfare_code_usage(
         self,
         db_session: AsyncSession,
@@ -345,15 +383,51 @@ class RedemptionService:
             结果字典,包含 success, valid, reason, redemption_code, error
         """
         try:
-            # 1. 查询兑换码
+            # 1. 优先按 settings 判断当前福利通用兑换码。
+            # 即使数据库里存在用于兼容历史记录外键的影子码，也不能影响当前福利码的真实有效性。
+            welfare_code = (await settings_service.get_setting(db_session, "welfare_common_code", "") or "").strip()
+            if welfare_code and code == welfare_code:
+                welfare_usage = await self.get_virtual_welfare_code_usage(db_session, welfare_code=welfare_code)
+                used_count = int(welfare_usage["used_count"] or 0)
+                effective_limit = int(welfare_usage["usable_capacity"] or 0)
+
+                if effective_limit <= 0 or used_count >= effective_limit:
+                    return {
+                        "success": True,
+                        "valid": False,
+                        "reason": "兑换码次数已用完，无法进行兑换",
+                        "redemption_code": None,
+                        "error": None
+                    }
+
+                return {
+                    "success": True,
+                    "valid": True,
+                    "reason": "兑换码有效",
+                    "redemption_code": {
+                        "id": None,
+                        "code": code,
+                        "status": "virtual_welfare",
+                        "expires_at": None,
+                        "created_at": None,
+                        "has_warranty": False,
+                        "warranty_days": 0,
+                        "pool_type": "welfare",
+                        "reusable_by_seat": True,
+                        "virtual_welfare_code": True,
+                        "limit": effective_limit,
+                        "used_count": used_count,
+                    },
+                    "error": None
+                }
+
+            # 2. 查询兑换码
             stmt = select(RedemptionCode).where(RedemptionCode.code == code)
             result = await db_session.execute(stmt)
             redemption_code = result.scalar_one_or_none()
 
             if not redemption_code:
                 # 兼容福利通用兑换码：只存 settings，不写 redemption_codes 表
-                from app.services.settings import settings_service
-                welfare_code = (await settings_service.get_setting(db_session, "welfare_common_code", "") or "").strip()
                 if welfare_code and code == welfare_code:
                     welfare_usage = await self.get_virtual_welfare_code_usage(db_session, welfare_code=welfare_code)
                     used_count = int(welfare_usage["used_count"] or 0)

--- a/tests/test_redeem_flow.py
+++ b/tests/test_redeem_flow.py
@@ -86,6 +86,7 @@ class RedeemFlowServiceTests(unittest.IsolatedAsyncioTestCase):
         )
         async with self.engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
+            await conn.execute(__import__("sqlalchemy").text("PRAGMA foreign_keys=ON"))
 
     async def asyncTearDown(self):
         await self.engine.dispose()
@@ -234,6 +235,44 @@ class RedeemFlowServiceTests(unittest.IsolatedAsyncioTestCase):
             ).scalar_one()
             self.assertEqual(mapping.status, "joined")
             self.assertEqual(mapping.missing_sync_count, 0)
+
+
+    async def test_virtual_welfare_code_creates_shadow_code_for_redemption_record(self):
+        async with self.session_factory() as session:
+            team = Team(
+                id=10,
+                email="welfare-owner@example.com",
+                access_token_encrypted="token-10",
+                account_id="acct-welfare",
+                team_name="Welfare Team",
+                current_members=1,
+                max_members=6,
+                status="active",
+                pool_type="welfare",
+            )
+            session.add(team)
+            await session.commit()
+
+            service = RedeemFlowService()
+            shadow = await service.redemption_service.ensure_virtual_welfare_shadow_code(session, "WELF-TEST-CODE")
+            await session.commit()
+
+            self.assertIsNotNone(shadow)
+            self.assertEqual(shadow.code, "WELF-TEST-CODE")
+            self.assertEqual(shadow.pool_type, "welfare")
+            self.assertTrue(shadow.reusable_by_seat)
+
+            record = RedemptionRecord(
+                email="user@example.com",
+                code="WELF-TEST-CODE",
+                team_id=10,
+                account_id="acct-welfare",
+            )
+            session.add(record)
+            await session.commit()
+
+            stored_record = (await session.execute(select(RedemptionRecord).where(RedemptionRecord.code == "WELF-TEST-CODE"))).scalar_one()
+            self.assertEqual(stored_record.team_id, 10)
 
     async def test_locked_team_returns_conflict_without_consuming_code(self):
         await self._seed_basic_data()


### PR DESCRIPTION
### Motivation
- Virtual welfare codes are stored in `settings` but redemption history `redemption_records.code` is a foreign key to `redemption_codes`, which can fail under SQLite foreign-key enforcement and stricter DB configurations.  
- The change ensures welfare-code redemptions remain compatible with the DB schema and avoids foreign-key constraint failures during redemption.

### Description
- Add `ensure_virtual_welfare_shadow_code` to `RedemptionService` to create/update a shadow `redemption_codes` row for the current welfare common code solely for FK compatibility, without changing the welfare-code validation semantics. (`app/services/redemption.py`)  
- Ensure the shadow code is created when an admin generates a new welfare common code. (`app/routes/admin.py`)  
- Ensure the shadow code exists before persisting a welfare redemption record during redeem flow (second-transaction hook). (`app/services/redeem_flow.py`)  
- Add a regression test that enables SQLite foreign key enforcement and verifies a welfare shadow code is created and a `RedemptionRecord` using the welfare code can be inserted. (`tests/test_redeem_flow.py`)  
- Minor test harness change: explicit `PRAGMA foreign_keys=ON` in in-memory test setup to catch FK regressions.

### Testing
- Ran `pytest -q` and the test suite passed: `6 passed, 1 skipped`.  
- Compiled code with `python -m compileall app tests` successfully.  
- Performed a manual foreign-key smoke check using an in-memory SQLite engine that printed `redemption_records 1`, confirming a welfare redemption record can be inserted when the shadow code exists.  
- No other automated tests regressed during verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bd13f9d01c83209949a52848921e14)