### PR TITLE
Fix toast visibility while modal is open

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1274,6 +1274,7 @@ body.admin-theme .toast {
 .toast {
     position: fixed;
     right: 1rem;
+    top: auto;
     bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
     width: min(420px, calc(100vw - 2rem));
     min-height: 52px;
@@ -1285,11 +1286,18 @@ body.admin-theme .toast {
     display: flex;
     align-items: center;
     gap: 0.75rem;
-    transform: translateY(calc(100% + 20px));
+    --toast-offset: calc(100% + 20px);
+    transform: translateY(var(--toast-offset));
     opacity: 0;
     transition: transform var(--transition-base), opacity var(--transition-fast);
     z-index: 4000;
     border: 1px solid var(--border-base);
+}
+
+body.modal-open .toast {
+    top: 1rem;
+    bottom: auto;
+    --toast-offset: calc(-100% - 20px);
 }
 
 .toast.show {


### PR DESCRIPTION
### Motivation
- Bottom-right toast notifications are hidden behind open modals during in-modal editing, so toasts must be visible when a modal is active.

### Description
- Modify `app/static/css/style.css` to introduce `--toast-offset` and a `body.modal-open .toast` rule that moves the global `.toast` to the top while preserving the existing bottom-right behaviour and the same show/hide animation.

### Testing
- Ran `python -m compileall app` and it completed without errors.
- No browser screenshot or end-to-end UI test was executed because a headless browser is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bdff9274548320af2fae627cd5aad3)