### PR TITLE
Mount toast inside open modals and adjust toast styling/positioning

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1274,6 +1274,7 @@ body.admin-theme .toast {
 .toast {
     position: fixed;
     right: 1rem;
+    top: auto;
     bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
     width: min(420px, calc(100vw - 2rem));
     min-height: 52px;
@@ -1285,11 +1286,23 @@ body.admin-theme .toast {
     display: flex;
     align-items: center;
     gap: 0.75rem;
-    transform: translateY(calc(100% + 20px));
+    --toast-offset: calc(100% + 20px);
+    transform: translateY(var(--toast-offset));
     opacity: 0;
     transition: transform var(--transition-base), opacity var(--transition-fast);
     z-index: 4000;
     border: 1px solid var(--border-base);
+    pointer-events: none;
+}
+
+.toast.in-modal {
+    position: absolute;
+    top: 5rem;
+    right: 1rem;
+    bottom: auto;
+    width: min(360px, calc(100% - 2rem));
+    --toast-offset: calc(-100% - 16px);
+    z-index: 30;
 }
 
 .toast.show {

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -121,9 +121,30 @@ async function initThemeSwitcher() {
 
 
 // Toast 提示函数
+let toastTimer = null;
+
+function getToastMountTarget() {
+    const openModal = document.querySelector('.modal-overlay.show .modal');
+    return openModal || document.body;
+}
+
+function syncToastMountTarget() {
+    const toast = document.getElementById('toast');
+    if (!toast) return;
+
+    const target = getToastMountTarget();
+    if (toast.parentElement !== target) {
+        target.appendChild(toast);
+    }
+
+    toast.classList.toggle('in-modal', target !== document.body);
+}
+
 function showToast(message, type = 'info') {
     const toast = document.getElementById('toast');
     if (!toast) return;
+
+    syncToastMountTarget();
 
     let icon = 'info';
     if (type === 'success') icon = 'check-circle';
@@ -131,13 +152,20 @@ function showToast(message, type = 'info') {
 
     toast.innerHTML = `<i data-lucide="${icon}"></i><span>${escapeHtml(message)}</span>`;
     toast.className = `toast ${type} show`;
+    toast.classList.toggle('in-modal', toast.parentElement !== document.body);
 
     if (window.lucide) {
         lucide.createIcons();
     }
 
-    setTimeout(() => {
+    if (toastTimer) {
+        clearTimeout(toastTimer);
+    }
+
+    toastTimer = setTimeout(() => {
         toast.classList.remove('show');
+        toastTimer = null;
+        syncToastMountTarget();
     }, 3000);
 }
 
@@ -148,6 +176,8 @@ function mountGlobalOverlayNodes() {
             document.body.appendChild(node);
         }
     });
+
+    syncToastMountTarget();
 }
 
 // 日期格式化函数
@@ -350,6 +380,8 @@ function showModal(modalId) {
         if (modalId === 'importTeamModal') {
             setSingleImportMode('quick');
         }
+
+        syncToastMountTarget();
     }
 }
 
@@ -384,6 +416,8 @@ function hideModal(modalId) {
         if (modalId === 'importTeamModal') {
             resetBatchImportForm();
         }
+
+        syncToastMountTarget();
     }
 }
 


### PR DESCRIPTION
### Motivation
- Toast notifications should appear inside open modal dialogs (instead of always fixed to the page bottom) and behave correctly when modals open/close.
- Update visual positioning and interaction so toasts in modals do not interfere with modal layout or page-level toasts.

### Description
- Added `getToastMountTarget()` and `syncToastMountTarget()` to move the toast DOM node between `document.body` and the active modal, and applied `in-modal` class when mounted inside a modal.
- Updated `showToast()` to synchronize mount target, debounce dismissal with `toastTimer`, and clear/restart the hide timeout to avoid races.
- Call `syncToastMountTarget()` from `mountGlobalOverlayNodes()`, `showModal()`, and `hideModal()` so toast placement is kept in sync with modal lifecycle.
- Adjusted CSS for `.toast` and added `.toast.in-modal` rules to change positioning, offsets, z-index, pointer-events, and sizing for modal-mounted toasts.

### Testing
- Ran automated linter via `npm run lint` and it completed successfully.
- Executed automated frontend unit tests via `npm test` and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bdff9274548320af2fae627cd5aad3)