### PR TITLE
修复右下角 toast 在模态框下被遮挡的问题

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1273,7 +1273,7 @@ body.admin-theme .toast {
 /* Toast */
 .toast {
     position: fixed;
-    right: 1rem;
+    right: max(1rem, env(safe-area-inset-right, 0px));
     top: auto;
     bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
     width: min(420px, calc(100vw - 2rem));
@@ -1282,43 +1282,29 @@ body.admin-theme .toast {
     background: var(--bg-surface);
     color: var(--text-main);
     border-radius: var(--radius-md);
-    box-shadow: var(--shadow-lg);
+    box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
     display: flex;
     align-items: center;
     gap: 0.75rem;
     --toast-offset: calc(100% + 20px);
-    transform: translateY(var(--toast-offset));
+    transform: translate3d(0, var(--toast-offset), 0);
     opacity: 0;
     transition: transform var(--transition-base), opacity var(--transition-fast);
-    z-index: 4000;
+    z-index: 10000;
     border: 1px solid var(--border-base);
     pointer-events: none;
+    isolation: isolate;
 }
 
-.toast.in-modal {
-    position: fixed;
-    top: auto;
-    right: max(1rem, env(safe-area-inset-right, 0px));
-    bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
-    width: min(360px, calc(100% - 2rem));
-    --toast-offset: calc(100% + 16px);
-    z-index: 4100;
+.toast.toast-over-modal {
     background: color-mix(in srgb, var(--toast-bg) 96%, var(--bg-surface) 4%);
     color: var(--text-main);
     border-color: color-mix(in srgb, var(--toast-border) 85%, var(--border-base) 15%);
-    backdrop-filter: none;
-    -webkit-backdrop-filter: none;
-    box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
-}
-
-body.modal-open .toast:not(.in-modal) {
-    top: 1rem;
-    bottom: auto;
-    --toast-offset: calc(-100% - 20px);
+    box-shadow: 0 22px 60px rgba(0, 0, 0, 0.34);
 }
 
 .toast.show {
-    transform: translateY(0);
+    transform: translate3d(0, 0, 0);
     opacity: 1;
 }
 

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -127,20 +127,15 @@ function hasVisibleModal() {
     return !!document.querySelector('.modal-overlay.show');
 }
 
-function getToastMountTarget() {
-    return document.body;
-}
-
 function syncToastMountTarget() {
     const toast = document.getElementById('toast');
     if (!toast) return;
 
-    const target = getToastMountTarget();
-    if (toast.parentElement !== target) {
-        target.appendChild(toast);
+    if (toast.parentElement !== document.body) {
+        document.body.appendChild(toast);
     }
 
-    toast.classList.toggle('in-modal', hasVisibleModal());
+    toast.classList.toggle('toast-over-modal', hasVisibleModal());
 }
 
 function showToast(message, type = 'info') {
@@ -155,7 +150,7 @@ function showToast(message, type = 'info') {
 
     toast.innerHTML = `<i data-lucide="${icon}"></i><span>${escapeHtml(message)}</span>`;
     toast.className = `toast ${type} show`;
-    toast.classList.toggle('in-modal', toast.parentElement !== document.body);
+    toast.classList.toggle('toast-over-modal', hasVisibleModal());
 
     if (window.lucide) {
         lucide.createIcons();

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -21,7 +21,7 @@
             }
         })();
     </script>
-    <link rel="stylesheet" href="/static/css/style.css?v=20260317-theme-layout-refresh-fix-1">
+    <link rel="stylesheet" href="/static/css/style.css?v=20260321-toast-modal-layer-fix-1">
     <!-- Lucide Icons -->
     <script src="https://unpkg.com/lucide@latest"></script>
     {% block extra_css %}{% endblock %}
@@ -426,7 +426,7 @@ eyJ..."></textarea>
     <div id="toast" class="toast"></div>
 
     <script>window.SYSTEM_UI_THEME = {{ ui_theme|default("ocean")|tojson }};</script>
-    <script src="/static/js/main.js?v=20260317-theme-layout-refresh-fix-1"></script>
+    <script src="/static/js/main.js?v=20260321-toast-modal-layer-fix-1"></script>
     <script>
         lucide.createIcons();
     </script>


### PR DESCRIPTION
### Motivation
- 编辑 Team / 成员管理 等操作时，右下角的提示框会被模态框的层级或父节点上下文影响，导致提示可见但看不清或被遮挡，需要保证提示总是清晰位于最上层。

### Description
- 在 `app/static/js/main.js` 中简化了 toast 挂载逻辑，始终将 `#toast` 挂载到 `document.body` 下并通过 `toast-over-modal` 类表示模态打开态。 
- 在 `app/static/css/style.css` 中提升了 toast 的堆叠层级到 `z-index: 10000`，改用 `translate3d` 动画并增加 `isolation`，并新增了 `.toast.toast-over-modal` 的视觉样式以在弹窗打开时强化可读性。 
- 在 `app/templates/base.html` 中更新了静态资源版本号（CSS/JS 链接查询参数），以便浏览器尽快拉取修复后的静态文件。 
- 主要改动文件：`app/static/js/main.js`、`app/static/css/style.css`、`app/templates/base.html`。 

### Testing
- 运行了 `python -m compileall app`，结果成功（无语法编译错误）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69be0ef21388832093e4f0977a0e3e4c)