### PR TITLE
Stream batch-refresh progress from backend and add UI progress panel; fix toast/modal layering

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -33,8 +33,6 @@ router = APIRouter(
     tags=["admin"]
 )
 
-import json
-
 # 服务实例
 team_service = TeamService()
 redemption_service = RedemptionService()
@@ -905,35 +903,72 @@ async def batch_refresh_teams(
     db: AsyncSession = Depends(get_db),
     current_user: dict = Depends(require_admin)
 ):
-    """
-    批量刷新 Team 信息
-    """
+    """批量刷新 Team 信息，并以流式方式返回进度。"""
     try:
-        logger.info(f"管理员批量刷新 {len(action_data.ids)} 个 Team")
-        
-        success_count = 0
-        failed_count = 0
-        
-        for team_id in action_data.ids:
-            try:
-                # 注意: 这里使用 sync_team_info, 它会自动处理 Token 刷新和信息同步
-                # force_refresh=True 代表强制同步 API
-                result = await team_service.sync_team_info(team_id, db, force_refresh=True)
-                if result.get("success"):
+        team_ids = [team_id for team_id in action_data.ids if isinstance(team_id, int)]
+        if not team_ids:
+            return JSONResponse(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                content={"success": False, "error": "请选择要刷新的 Team"}
+            )
+
+        logger.info(f"管理员批量刷新 {len(team_ids)} 个 Team")
+
+        async def progress_generator():
+            success_count = 0
+            failed_count = 0
+            total = len(team_ids)
+
+            yield json.dumps({
+                "type": "start",
+                "total": total,
+                "success_count": success_count,
+                "failed_count": failed_count,
+            }, ensure_ascii=False) + "\n"
+
+            for index, team_id in enumerate(team_ids, start=1):
+                item_success = False
+                item_error = None
+                item_message = None
+
+                try:
+                    result = await team_service.sync_team_info(team_id, db, force_refresh=True)
+                    item_success = bool(result.get("success"))
+                    item_message = result.get("message")
+                    item_error = result.get("error")
+                except Exception as ex:
+                    logger.error(f"批量刷新 Team {team_id} 时出错: {ex}")
+                    item_error = str(ex)
+
+                if item_success:
                     success_count += 1
                 else:
                     failed_count += 1
-            except Exception as ex:
-                logger.error(f"批量刷新 Team {team_id} 时出错: {ex}")
-                failed_count += 1
-        
-        return JSONResponse(content={
-            "success": True,
-            "message": f"批量刷新完成: 成功 {success_count}, 失败 {failed_count}",
-            "success_count": success_count,
-            "failed_count": failed_count
-        })
-    except Exception as e:
+
+                yield json.dumps({
+                    "type": "progress",
+                    "current": index,
+                    "total": total,
+                    "success_count": success_count,
+                    "failed_count": failed_count,
+                    "team_id": team_id,
+                    "last_result": {
+                        "success": item_success,
+                        "message": item_message,
+                        "error": item_error,
+                    }
+                }, ensure_ascii=False) + "\n"
+
+            yield json.dumps({
+                "type": "finish",
+                "total": total,
+                "success_count": success_count,
+                "failed_count": failed_count,
+                "message": f"批量刷新完成: 成功 {success_count}, 失败 {failed_count}"
+            }, ensure_ascii=False) + "\n"
+
+        return StreamingResponse(progress_generator(), media_type="application/x-ndjson")
+    except Exception:
         logger.exception("批量刷新 Team 失败")
         return JSONResponse(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1273,7 +1273,7 @@ body.admin-theme .toast {
 /* Toast */
 .toast {
     position: fixed;
-    right: 1rem;
+    right: max(1rem, env(safe-area-inset-right, 0px));
     top: auto;
     bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
     width: min(420px, calc(100vw - 2rem));
@@ -1282,43 +1282,29 @@ body.admin-theme .toast {
     background: var(--bg-surface);
     color: var(--text-main);
     border-radius: var(--radius-md);
-    box-shadow: var(--shadow-lg);
+    box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
     display: flex;
     align-items: center;
     gap: 0.75rem;
     --toast-offset: calc(100% + 20px);
-    transform: translateY(var(--toast-offset));
+    transform: translate3d(0, var(--toast-offset), 0);
     opacity: 0;
     transition: transform var(--transition-base), opacity var(--transition-fast);
-    z-index: 4000;
+    z-index: 10000;
     border: 1px solid var(--border-base);
     pointer-events: none;
+    isolation: isolate;
 }
 
-.toast.in-modal {
-    position: fixed;
-    top: auto;
-    right: max(1rem, env(safe-area-inset-right, 0px));
-    bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
-    width: min(360px, calc(100% - 2rem));
-    --toast-offset: calc(100% + 16px);
-    z-index: 4100;
+.toast.toast-over-modal {
     background: color-mix(in srgb, var(--toast-bg) 96%, var(--bg-surface) 4%);
     color: var(--text-main);
     border-color: color-mix(in srgb, var(--toast-border) 85%, var(--border-base) 15%);
-    backdrop-filter: none;
-    -webkit-backdrop-filter: none;
-    box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
-}
-
-body.modal-open .toast:not(.in-modal) {
-    top: 1rem;
-    bottom: auto;
-    --toast-offset: calc(-100% - 20px);
+    box-shadow: 0 22px 60px rgba(0, 0, 0, 0.34);
 }
 
 .toast.show {
-    transform: translateY(0);
+    transform: translate3d(0, 0, 0);
     opacity: 1;
 }
 

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -127,20 +127,15 @@ function hasVisibleModal() {
     return !!document.querySelector('.modal-overlay.show');
 }
 
-function getToastMountTarget() {
-    return document.body;
-}
-
 function syncToastMountTarget() {
     const toast = document.getElementById('toast');
     if (!toast) return;
 
-    const target = getToastMountTarget();
-    if (toast.parentElement !== target) {
-        target.appendChild(toast);
+    if (toast.parentElement !== document.body) {
+        document.body.appendChild(toast);
     }
 
-    toast.classList.toggle('in-modal', hasVisibleModal());
+    toast.classList.toggle('toast-over-modal', hasVisibleModal());
 }
 
 function showToast(message, type = 'info') {
@@ -155,7 +150,7 @@ function showToast(message, type = 'info') {
 
     toast.innerHTML = `<i data-lucide="${icon}"></i><span>${escapeHtml(message)}</span>`;
     toast.className = `toast ${type} show`;
-    toast.classList.toggle('in-modal', toast.parentElement !== document.body);
+    toast.classList.toggle('toast-over-modal', hasVisibleModal());
 
     if (window.lucide) {
         lucide.createIcons();

--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -2,6 +2,96 @@
 
 {% block title %}{% if active_page == "welfare" %}福利车位 - GPT Team 管理系统{% else %}控制台 - GPT Team 管理系统{% endif %}{% endblock %}
 
+{% block extra_css %}
+<style>
+    .batch-progress-panel {
+        position: fixed;
+        left: 1rem;
+        bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
+        width: min(360px, calc(100vw - 2rem));
+        background: color-mix(in srgb, var(--bg-surface) 96%, #0f172a 4%);
+        border: 1px solid var(--border-base);
+        border-radius: var(--radius-lg);
+        box-shadow: 0 20px 50px rgba(15, 23, 42, 0.22);
+        padding: 1rem;
+        z-index: 9500;
+        display: none;
+    }
+
+    .batch-progress-panel.show {
+        display: block;
+    }
+
+    .batch-progress-title {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+        margin-bottom: 0.75rem;
+        font-weight: 600;
+    }
+
+    .batch-progress-meta {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 0.5rem;
+        margin-bottom: 0.75rem;
+    }
+
+    .batch-progress-stat {
+        padding: 0.65rem 0.75rem;
+        border-radius: var(--radius-md);
+        background: var(--bg-muted);
+        text-align: center;
+    }
+
+    .batch-progress-stat strong {
+        display: block;
+        font-size: 1rem;
+        color: var(--text-main);
+    }
+
+    .batch-progress-stat span {
+        font-size: 0.78rem;
+        color: var(--text-muted);
+    }
+
+    .batch-progress-bar {
+        width: 100%;
+        height: 10px;
+        border-radius: 999px;
+        background: var(--bg-muted);
+        overflow: hidden;
+        margin-bottom: 0.65rem;
+    }
+
+    .batch-progress-bar-inner {
+        height: 100%;
+        width: 0%;
+        background: linear-gradient(90deg, var(--info), var(--success));
+        transition: width 0.2s ease;
+    }
+
+    .batch-progress-text {
+        font-size: 0.85rem;
+        color: var(--text-muted);
+        line-height: 1.5;
+    }
+
+    .batch-progress-text strong {
+        color: var(--text-main);
+    }
+
+    @media (max-width: 640px) {
+        .batch-progress-panel {
+            left: 0.75rem;
+            right: 0.75rem;
+            width: auto;
+        }
+    }
+</style>
+{% endblock %}
+
 {% block content %}
 <div class="page-header">
     <h2>{% if active_page == "welfare" %}福利车位{% else %}控制台{% endif %}</h2>
@@ -61,6 +151,31 @@
         </div>
     </div>
     {% endif %}
+</div>
+
+<div id="batchRefreshProgress" class="batch-progress-panel" aria-live="polite" aria-atomic="true">
+    <div class="batch-progress-title">
+        <span>批量刷新进度</span>
+        <span id="batchRefreshProgressPercent" class="text-muted">0%</span>
+    </div>
+    <div class="batch-progress-meta">
+        <div class="batch-progress-stat">
+            <strong id="batchRefreshProgressCurrent">0 / 0</strong>
+            <span>当前进度</span>
+        </div>
+        <div class="batch-progress-stat">
+            <strong id="batchRefreshProgressSuccess">0</strong>
+            <span>成功</span>
+        </div>
+        <div class="batch-progress-stat">
+            <strong id="batchRefreshProgressFailed">0</strong>
+            <span>失败</span>
+        </div>
+    </div>
+    <div class="batch-progress-bar">
+        <div id="batchRefreshProgressBar" class="batch-progress-bar-inner"></div>
+    </div>
+    <div id="batchRefreshProgressText" class="batch-progress-text">等待开始…</div>
 </div>
 
 <!-- Team 列表 -->
@@ -446,9 +561,6 @@
         </div>
     </div>
 </div>
-{% endblock %}
-
-{% block extra_css %}
 {% endblock %}
 
 {% block extra_js %}
@@ -945,9 +1057,52 @@
         }
     }
 
+    function getSelectedTeamIds() {
+        return Array.from(document.querySelectorAll('.team-checkbox:checked'))
+            .map(cb => parseInt(cb.value, 10))
+            .filter(id => Number.isFinite(id));
+    }
+
+    function setBatchActionButtonsDisabled(disabled) {
+        ['btnBatchRefresh', 'btnBatchEnableDeviceAuth', 'btnBatchDelete'].forEach(id => {
+            const button = document.getElementById(id);
+            if (button) button.disabled = disabled;
+        });
+    }
+
+    function updateBatchRefreshProgress({ current, total, success, failed, text }) {
+        const panel = document.getElementById('batchRefreshProgress');
+        const currentNode = document.getElementById('batchRefreshProgressCurrent');
+        const successNode = document.getElementById('batchRefreshProgressSuccess');
+        const failedNode = document.getElementById('batchRefreshProgressFailed');
+        const barNode = document.getElementById('batchRefreshProgressBar');
+        const percentNode = document.getElementById('batchRefreshProgressPercent');
+        const textNode = document.getElementById('batchRefreshProgressText');
+        if (!panel || !currentNode || !successNode || !failedNode || !barNode || !percentNode || !textNode) return;
+
+        const safeTotal = total > 0 ? total : 1;
+        const percent = Math.max(0, Math.min(100, Math.round((current / safeTotal) * 100)));
+
+        currentNode.textContent = `${Math.min(current, total)} / ${total}`;
+        successNode.textContent = `${success}`;
+        failedNode.textContent = `${failed}`;
+        barNode.style.width = `${percent}%`;
+        percentNode.textContent = `${percent}%`;
+        textNode.innerHTML = text;
+    }
+
+    function showBatchRefreshProgress() {
+        document.getElementById('batchRefreshProgress')?.classList.add('show');
+    }
+
+    function hideBatchRefreshProgress(delay = 0) {
+        const panel = document.getElementById('batchRefreshProgress');
+        if (!panel) return;
+        window.setTimeout(() => panel.classList.remove('show'), delay);
+    }
+
     async function handleBatchAction(endpoint, actionName) {
-        const selectedIds = Array.from(document.querySelectorAll('.team-checkbox:checked'))
-            .map(cb => parseInt(cb.value));
+        const selectedIds = getSelectedTeamIds();
 
         if (selectedIds.length === 0) {
             showToast('请选择要操作的 Team', 'warning');
@@ -960,6 +1115,8 @@
 
         try {
             showToast(`正在${actionName}...`, 'info');
+            setBatchActionButtonsDisabled(true);
+
             const response = await fetch(endpoint, {
                 method: 'POST',
                 headers: {
@@ -979,11 +1136,121 @@
         } catch (error) {
             console.error(error);
             showToast('网络错误', 'error');
+        } finally {
+            setBatchActionButtonsDisabled(false);
         }
     }
 
-    function handleBatchRefresh() {
-        handleBatchAction('/admin/teams/batch-refresh', '批量刷新');
+    async function handleBatchRefresh() {
+        const selectedIds = getSelectedTeamIds();
+
+        if (selectedIds.length === 0) {
+            showToast('请选择要刷新的 Team', 'warning');
+            return;
+        }
+
+        if (!confirm(`确定要批量刷新选中的 ${selectedIds.length} 个 Team 吗？`)) {
+            return;
+        }
+
+        showBatchRefreshProgress();
+        setBatchActionButtonsDisabled(true);
+        updateBatchRefreshProgress({
+            current: 0,
+            total: selectedIds.length,
+            success: 0,
+            failed: 0,
+            text: `准备开始，共 <strong>${selectedIds.length}</strong> 个 Team…`
+        });
+        showToast(`开始批量刷新，共 ${selectedIds.length} 个 Team`, 'info');
+
+        try {
+            const response = await fetch('/admin/teams/batch-refresh', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ ids: selectedIds })
+            });
+
+            if (!response.ok || !response.body) {
+                let errorMessage = '批量刷新失败';
+                try {
+                    const errorData = await response.json();
+                    errorMessage = errorData.error || errorMessage;
+                } catch (error) {
+                    console.error('解析批量刷新错误响应失败', error);
+                }
+                throw new Error(errorMessage);
+            }
+
+            const reader = response.body.getReader();
+            const decoder = new TextDecoder('utf-8');
+            let buffer = '';
+            let finalResult = null;
+
+            while (true) {
+                const { value, done } = await reader.read();
+                buffer += decoder.decode(value || new Uint8Array(), { stream: !done });
+
+                const lines = buffer.split('\n');
+                buffer = lines.pop() || '';
+
+                for (const rawLine of lines) {
+                    const line = rawLine.trim();
+                    if (!line) continue;
+
+                    const data = JSON.parse(line);
+
+                    if (data.type === 'start') {
+                        updateBatchRefreshProgress({
+                            current: 0,
+                            total: data.total || selectedIds.length,
+                            success: data.success_count || 0,
+                            failed: data.failed_count || 0,
+                            text: `服务端已开始顺序刷新，共 <strong>${data.total || selectedIds.length}</strong> 个 Team…`
+                        });
+                    } else if (data.type === 'progress') {
+                        updateBatchRefreshProgress({
+                            current: data.current || 0,
+                            total: data.total || selectedIds.length,
+                            success: data.success_count || 0,
+                            failed: data.failed_count || 0,
+                            text: `服务端正在刷新第 <strong>${data.current || 0}</strong> / <strong>${data.total || selectedIds.length}</strong> 个 Team（ID: ${data.team_id || '-'}）…`
+                        });
+                    } else if (data.type === 'finish') {
+                        finalResult = data;
+                        updateBatchRefreshProgress({
+                            current: data.total || selectedIds.length,
+                            total: data.total || selectedIds.length,
+                            success: data.success_count || 0,
+                            failed: data.failed_count || 0,
+                            text: `批量刷新完成：成功 <strong>${data.success_count || 0}</strong>，失败 <strong>${data.failed_count || 0}</strong>。页面即将自动刷新。`
+                        });
+                    } else if (data.type === 'error') {
+                        throw new Error(data.error || '批量刷新失败');
+                    }
+                }
+
+                if (done) {
+                    break;
+                }
+            }
+
+            const successCount = finalResult?.success_count || 0;
+            const failedCount = finalResult?.failed_count || 0;
+            showToast(
+                finalResult?.message || `批量刷新完成：成功 ${successCount}，失败 ${failedCount}`,
+                failedCount > 0 ? 'warning' : 'success'
+            );
+            setTimeout(() => location.reload(), 1500);
+        } catch (error) {
+            console.error(error);
+            showToast(error.message || '批量刷新失败', 'error');
+        } finally {
+            setBatchActionButtonsDisabled(false);
+            hideBatchRefreshProgress(2500);
+        }
     }
 
     function handleBatchDelete() {

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -21,7 +21,7 @@
             }
         })();
     </script>
-    <link rel="stylesheet" href="/static/css/style.css?v=20260317-theme-layout-refresh-fix-1">
+    <link rel="stylesheet" href="/static/css/style.css?v=20260321-toast-modal-layer-fix-1">
     <!-- Lucide Icons -->
     <script src="https://unpkg.com/lucide@latest"></script>
     {% block extra_css %}{% endblock %}
@@ -426,7 +426,7 @@ eyJ..."></textarea>
     <div id="toast" class="toast"></div>
 
     <script>window.SYSTEM_UI_THEME = {{ ui_theme|default("ocean")|tojson }};</script>
-    <script src="/static/js/main.js?v=20260317-theme-layout-refresh-fix-1"></script>
+    <script src="/static/js/main.js?v=20260321-toast-modal-layer-fix-1"></script>
     <script>
         lucide.createIcons();
     </script>


### PR DESCRIPTION
### Motivation

- Provide real-time feedback for administrators when running batch Team refresh operations to improve UX and avoid long blocking requests. 
- Ensure toast notifications are correctly layered above or over modal content and respect safe-area insets on modern devices. 

### Description

- Replace the previous synchronous `batch_refresh_teams` behavior with a streaming NDJSON `StreamingResponse` that validates numeric IDs and yields `start`/`progress`/`finish` events while iterating teams and calling `team_service.sync_team_info`.
- Add client-side streaming handling in `main.js` that reads the response `ReadableStream`, parses NDJSON chunks, updates a new progress panel, disables batch action buttons during the operation, and shows appropriate toast messages on completion or error.
- Introduce a new batch progress UI in `admin/index.html` including styles and markup, and wire up selection helpers and UI state updates (`getSelectedTeamIds`, `updateBatchRefreshProgress`, `showBatchRefreshProgress`, `hideBatchRefreshProgress`, `setBatchActionButtonsDisabled`).
- Improve toast/modal layering and safe-area handling in `style.css` by using `env(safe-area-inset-right/bottom)`, switching to `translate3d`, increasing toast `z-index`, adding `isolation: isolate`, and replacing the `.in-modal` class with `.toast-over-modal` to control appearance over modals.
- Simplify toast mount logic in `main.js` to always mount to `document.body` and toggle the new `.toast-over-modal` class, and update asset version strings in `base.html` to reference the updated CSS/JS.

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69be0ef21388832093e4f0977a0e3e4c)