### PR TITLE
Fix virtual welfare counting, warranty checks, and seat rollback; require admin for device auth

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -219,7 +219,7 @@ async def welfare_dashboard(
         welfare_usage = await redemption_service.get_virtual_welfare_code_usage(db)
         welfare_code = str(welfare_usage.get("welfare_code") or "")
         welfare_used = int(welfare_usage.get("used_count") or 0)
-        effective_limit = max(int(welfare_usage.get("usable_capacity") or 0), 0)
+        effective_limit = max(int(welfare_usage.get("remaining_count") or 0), 0)
 
         stats = {
             "total_teams": team_stats["total"],
@@ -228,7 +228,7 @@ async def welfare_dashboard(
             "welfare_code": welfare_code,
             "welfare_code_limit": effective_limit,
             "welfare_code_used": welfare_used,
-            "welfare_code_remaining": max(effective_limit - welfare_used, 0),
+            "welfare_code_remaining": effective_limit,
         }
 
         return templates.TemplateResponse(

--- a/app/routes/warranty.py
+++ b/app/routes/warranty.py
@@ -8,6 +8,7 @@ from typing import Optional
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
+from app.dependencies.auth import require_admin
 from app.services.warranty import warranty_service
 
 router = APIRouter(
@@ -121,33 +122,15 @@ class EnableDeviceAuthRequest(BaseModel):
 @router.post("/enable-device-auth")
 async def enable_device_auth(
     request: EnableDeviceAuthRequest,
-    db_session: AsyncSession = Depends(get_db)
+    db_session: AsyncSession = Depends(get_db),
+    current_user: dict = Depends(require_admin)
 ):
     """
-    用户一键开启设备身份验证
+    仅管理员可开启设备身份验证
     """
     from app.services.team import team_service
-    from sqlalchemy import select
-    from app.models import RedemptionRecord
 
     try:
-        # 1. 验证用户是否有记录在该 Team
-        stmt = select(RedemptionRecord).where(
-            RedemptionRecord.code == request.code,
-            RedemptionRecord.email == request.email,
-            RedemptionRecord.team_id == request.team_id
-        )
-        result = await db_session.execute(stmt)
-        record = result.scalar_one_or_none()
-        
-        if not record:
-            raise HTTPException(
-                status_code=403,
-                detail="未找到相关的兑换记录，无法进行该操作"
-            )
-            
-        # 2. 调用 TeamService 开启
-        # 注意：这里我们使用已经实现的 enable_device_code_auth
         res = await team_service.enable_device_code_auth(request.team_id, db_session)
         
         if not res.get("success"):

--- a/app/services/redeem_flow.py
+++ b/app/services/redeem_flow.py
@@ -386,10 +386,15 @@ class RedeemFlowService:
                                         if seat_reserved:
                                             target_team.current_members = max(
                                                 target_team.current_members - 1,
-                                                target_team.max_members
+                                                0
                                             )
                                             seat_reserved = False
-                                        target_team.status = "full"
+                                        if target_team.current_members >= target_team.max_members:
+                                            target_team.status = "full"
+                                        elif target_team.expires_at and target_team.expires_at < get_now():
+                                            target_team.status = "expired"
+                                        else:
+                                            target_team.status = "active"
                                         await db_session.commit()
                                         raise Exception(f"该 Team 席位已满 (API Error: {err})")
 

--- a/app/services/redemption.py
+++ b/app/services/redemption.py
@@ -132,6 +132,7 @@ class RedemptionService:
             "welfare_code": welfare_code,
             "used_count": used_count,
             "usable_capacity": usable_capacity,
+            "remaining_count": usable_capacity,
         }
 
     async def _rebuild_code_usage_state(
@@ -389,9 +390,9 @@ class RedemptionService:
             if welfare_code and code == welfare_code:
                 welfare_usage = await self.get_virtual_welfare_code_usage(db_session, welfare_code=welfare_code)
                 used_count = int(welfare_usage["used_count"] or 0)
-                effective_limit = int(welfare_usage["usable_capacity"] or 0)
+                effective_limit = int(welfare_usage["remaining_count"] or 0)
 
-                if effective_limit <= 0 or used_count >= effective_limit:
+                if effective_limit <= 0:
                     return {
                         "success": True,
                         "valid": False,
@@ -431,9 +432,9 @@ class RedemptionService:
                 if welfare_code and code == welfare_code:
                     welfare_usage = await self.get_virtual_welfare_code_usage(db_session, welfare_code=welfare_code)
                     used_count = int(welfare_usage["used_count"] or 0)
-                    effective_limit = int(welfare_usage["usable_capacity"] or 0)
+                    effective_limit = int(welfare_usage["remaining_count"] or 0)
 
-                    if effective_limit <= 0 or used_count >= effective_limit:
+                    if effective_limit <= 0:
                         return {
                             "success": True,
                             "valid": False,
@@ -524,7 +525,23 @@ class RedemptionService:
                         "error": None
                     }
 
-            # 4. 检查是否过期 (仅针对未使用的兑换码执行首次激活截止时间检查)
+            # 4. 检查质保是否已过期（针对已使用的质保码）
+            if (
+                redemption_code.has_warranty
+                and redemption_code.status == "used"
+                and redemption_code.warranty_expires_at
+                and redemption_code.warranty_expires_at < get_now()
+            ):
+                redemption_code.status = "expired"
+                return {
+                    "success": True,
+                    "valid": False,
+                    "reason": "质保已过期",
+                    "redemption_code": None,
+                    "error": None
+                }
+
+            # 5. 检查是否过期 (仅针对未使用的兑换码执行首次激活截止时间检查)
             if redemption_code.status == "unused" and redemption_code.expires_at:
                 if redemption_code.expires_at < get_now():
                     # 更新状态为 expired
@@ -540,7 +557,7 @@ class RedemptionService:
                         "error": None
                     }
 
-            # 5. 验证通过
+            # 6. 验证通过
             return {
                 "success": True,
                 "valid": True,

--- a/app/services/warranty.py
+++ b/app/services/warranty.py
@@ -238,6 +238,7 @@ class WarrantyService:
             primary_expiry = None
             primary_code = None
             can_reuse = False
+            suspected_inconsistent_count = 0
 
             for record, code_obj, team in records_data:
                 # 1.1 实时一致性校验 (自愈逻辑)
@@ -248,11 +249,39 @@ class WarrantyService:
                     member_emails = [m.lower() for m in sync_res.get("member_emails", [])]
                     
                     if record.email.lower() not in member_emails:
-                        logger.warning(f"自愈逻辑(查询触发): 发现孤儿记录 (Email: {record.email}, Team: {team.id}), API 查无此人。正在执行自动清理。")
-                        await db_session.delete(record)
-                        await db_session.commit()
-                        # 跳过这条无效记录，提示用户重新兑换
-                        continue 
+                        expiry_date = await self._resolve_warranty_expiry_date(
+                            db_session,
+                            code_obj,
+                            reference_record=record,
+                            expiration_mode=warranty_expiration_mode
+                        )
+                        is_valid = self._is_warranty_valid(code_obj, expiry_date)
+                        if code_obj.has_warranty:
+                            has_any_warranty = True
+                            if primary_code is None:
+                                primary_warranty_valid = is_valid
+                                primary_expiry = expiry_date
+                                primary_code = code_obj.code
+                        logger.warning(
+                            f"质保查询发现疑似孤儿记录 (Email: {record.email}, Team: {team.id})，"
+                            "为避免误删售后证据，本次仅标记异常，不执行自动清理。"
+                        )
+                        suspected_inconsistent_count += 1
+                        final_records.append({
+                            "code": code_obj.code,
+                            "has_warranty": code_obj.has_warranty,
+                            "warranty_valid": is_valid,
+                            "warranty_expires_at": expiry_date.isoformat() if expiry_date else None,
+                            "status": code_obj.status,
+                            "used_at": record.redeemed_at.isoformat() if record.redeemed_at else None,
+                            "team_id": team.id,
+                            "team_name": team.team_name,
+                            "team_status": "suspected_inconsistent",
+                            "team_expires_at": team.expires_at.isoformat() if team.expires_at else None,
+                            "email": record.email,
+                            "device_code_auth_enabled": team.device_code_auth_enabled
+                        })
+                        continue
 
                 # 动态计算/提取质保信息
                 expiry_date = await self._resolve_warranty_expiry_date(
@@ -307,6 +336,8 @@ class WarrantyService:
                 # 这种情况说明刚才所有记录都被自愈逻辑删除了（全是虚假成功）
                 message = "系统发现您的兑换记录存在同步异常，已为您自动修复！您的兑换码已恢复，请返回兑换页面重新提交一次即可。"
                 can_reuse = True
+            elif suspected_inconsistent_count > 0:
+                message = "检测到部分兑换记录与远端成员状态不一致；系统已保留原始记录，请联系管理员进一步核查。"
 
             return {
                 "success": True,
@@ -424,20 +455,14 @@ class WarrantyService:
                                 "error": None
                             }
 
-            # 刷新记录列表 (可能在上面自愈逻辑中删除了孤儿记录)
-            stmt = select(RedemptionRecord).where(RedemptionRecord.code == code)
-            result = await db_session.execute(stmt)
-            all_records_for_code = result.scalars().all()
-
             # 5. 查找当前用户使用该兑换码的记录 (用于后续逻辑判断)
             records = [r for r in all_records_for_code if r.email == email]
             
             if not records:
-                # 之前没有该邮箱的记录，但上面已经检查过没有其他活跃 Team 了，所以允许“新开”或“接手”
                 return {
                     "success": True,
-                    "can_reuse": True,
-                    "reason": "可更名使用 (或首次使用)",
+                    "can_reuse": False,
+                    "reason": "质保兑换码仅限原使用邮箱申请售后，不支持更名接手",
                     "error": None
                 }
 

--- a/tests/test_redeem_flow.py
+++ b/tests/test_redeem_flow.py
@@ -1,5 +1,6 @@
 import asyncio
 import unittest
+from datetime import timedelta
 from unittest.mock import patch
 
 from sqlalchemy import select
@@ -8,8 +9,12 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from app.database import Base
 from app.models import RedemptionCode, RedemptionRecord, Team, TeamEmailMapping
 from app.services.redeem_flow import RedeemFlowService
+from app.services.notification import notification_service
 from app.services.redemption import RedemptionService
+from app.services.settings import settings_service
 from app.services.team import TeamService
+from app.services.warranty import WarrantyService
+from app.utils.time_utils import get_now
 
 
 class StubRedemptionService:
@@ -169,6 +174,10 @@ class RedeemFlowServiceTests(unittest.IsolatedAsyncioTestCase):
     @staticmethod
     def _close_coro(coro):
         coro.close()
+        return None
+
+    @staticmethod
+    async def _noop_async(*args, **kwargs):
         return None
 
     async def test_auto_select_skips_team_where_user_already_exists(self):
@@ -466,3 +475,272 @@ class RedeemFlowServiceTests(unittest.IsolatedAsyncioTestCase):
             records = (await session.execute(select(RedemptionRecord))).scalars().all()
             self.assertEqual(len(records), 1)
             self.assertEqual(records[0].team_id, 2)
+
+    async def test_validate_code_rejects_expired_warranty_code(self):
+        async with self.session_factory() as session:
+            code = RedemptionCode(
+                code="WARRANTY-EXPIRED-001",
+                status="used",
+                has_warranty=True,
+                warranty_days=30,
+                used_at=get_now() - timedelta(days=40),
+                warranty_expires_at=get_now() - timedelta(days=10),
+            )
+            session.add(code)
+            await session.commit()
+
+            service = RedemptionService()
+            result = await service.validate_code("WARRANTY-EXPIRED-001", session)
+
+            self.assertTrue(result["success"])
+            self.assertFalse(result["valid"])
+            self.assertEqual(result["reason"], "质保已过期")
+
+            refreshed_code = (
+                await session.execute(
+                    select(RedemptionCode).where(RedemptionCode.code == "WARRANTY-EXPIRED-001")
+                )
+            ).scalar_one()
+            self.assertEqual(refreshed_code.status, "expired")
+
+    async def test_warranty_reuse_rejects_email_handoff(self):
+        async with self.session_factory() as session:
+            team = Team(
+                id=40,
+                email="owner-40@example.com",
+                access_token_encrypted="token-40",
+                account_id="acct-40",
+                team_name="Old Team",
+                current_members=6,
+                max_members=6,
+                status="expired",
+                pool_type="normal",
+            )
+            code = RedemptionCode(
+                code="WARRANTY-HANDOFF-001",
+                status="used",
+                has_warranty=True,
+                warranty_days=30,
+                used_at=get_now() - timedelta(days=3),
+                warranty_expires_at=get_now() + timedelta(days=27),
+            )
+            record = RedemptionRecord(
+                email="buyer@example.com",
+                code="WARRANTY-HANDOFF-001",
+                team_id=40,
+                account_id="acct-40",
+                is_warranty_redemption=False,
+            )
+            session.add_all([team, code, record])
+            await session.commit()
+
+            service = WarrantyService()
+            result = await service.validate_warranty_reuse(
+                session,
+                "WARRANTY-HANDOFF-001",
+                "attacker@example.com",
+            )
+
+            self.assertTrue(result["success"])
+            self.assertFalse(result["can_reuse"])
+            self.assertIn("仅限原使用邮箱", result["reason"])
+
+    async def test_warranty_check_keeps_record_when_sync_misses_member(self):
+        async with self.session_factory() as session:
+            team = Team(
+                id=50,
+                email="owner-50@example.com",
+                access_token_encrypted="token-50",
+                account_id="acct-50",
+                team_name="Sync Team",
+                current_members=2,
+                max_members=6,
+                status="active",
+                pool_type="normal",
+            )
+            code = RedemptionCode(
+                code="WARRANTY-CHECK-001",
+                status="used",
+                has_warranty=True,
+                warranty_days=30,
+                used_at=get_now() - timedelta(days=1),
+                warranty_expires_at=get_now() + timedelta(days=29),
+            )
+            record = RedemptionRecord(
+                email="buyer@example.com",
+                code="WARRANTY-CHECK-001",
+                team_id=50,
+                account_id="acct-50",
+            )
+            session.add_all([team, code, record])
+            await session.commit()
+
+            service = WarrantyService()
+            service.team_service = StubTeamService(sync_results={50: [{"success": True, "member_emails": []}]})
+
+            result = await service.check_warranty_status(
+                session,
+                code="WARRANTY-CHECK-001",
+            )
+
+            self.assertTrue(result["success"])
+            self.assertTrue(result["has_warranty"])
+            self.assertEqual(len(result["records"]), 1)
+            self.assertEqual(result["records"][0]["team_status"], "suspected_inconsistent")
+            self.assertIn("保留原始记录", result["message"])
+
+            stored_records = (
+                await session.execute(
+                    select(RedemptionRecord).where(RedemptionRecord.code == "WARRANTY-CHECK-001")
+                )
+            ).scalars().all()
+            self.assertEqual(len(stored_records), 1)
+
+    async def test_seat_rolls_back_after_full_error(self):
+        await self._seed_basic_data()
+        service = RedeemFlowService()
+        service.redemption_service = StubRedemptionService()
+        service.team_service = StubTeamService()
+        service.chatgpt_service = StubChatGPTService(
+            {
+                "acct-1": [{"success": False, "error": "maximum number of seats reached"}],
+            }
+        )
+
+        async with self.session_factory() as session:
+            team_1 = await session.get(Team, 1)
+            team_1.current_members = 5
+            team_1.max_members = 6
+            await session.commit()
+
+            with patch("app.services.redeem_flow.asyncio.create_task", side_effect=self._close_coro):
+                result = await service.redeem_and_join_team(
+                    email="user@example.com",
+                    code="TEST-CODE-0001",
+                    team_id=1,
+                    db_session=session,
+                )
+
+            self.assertFalse(result["success"])
+            self.assertIn("席位已满", result["error"])
+
+            refreshed_team = await session.get(Team, 1)
+            self.assertEqual(refreshed_team.current_members, 5)
+            self.assertEqual(refreshed_team.status, "active")
+
+    async def test_virtual_welfare_code_usage_does_not_double_decrement_remaining(self):
+        async with self.session_factory() as session:
+            welfare_team = Team(
+                id=60,
+                email="welfare-owner@example.com",
+                access_token_encrypted="token-60",
+                account_id="acct-60",
+                team_name="Welfare Pool",
+                current_members=2,
+                max_members=5,
+                status="active",
+                pool_type="welfare",
+            )
+            session.add(welfare_team)
+            await session.commit()
+
+            service = RedemptionService()
+            await service.ensure_virtual_welfare_shadow_code(session, "WELF-CODE-001")
+            settings_service.clear_cache()
+            await settings_service.update_setting(session, "welfare_common_code", "WELF-CODE-001")
+            session.add_all([
+                RedemptionRecord(
+                    email="one@example.com",
+                    code="WELF-CODE-001",
+                    team_id=60,
+                    account_id="acct-60",
+                ),
+                RedemptionRecord(
+                    email="two@example.com",
+                    code="WELF-CODE-001",
+                    team_id=60,
+                    account_id="acct-60",
+                ),
+            ])
+            await session.commit()
+
+            usage = await service.get_virtual_welfare_code_usage(session, welfare_code="WELF-CODE-001")
+            self.assertEqual(usage["used_count"], 2)
+            self.assertEqual(usage["usable_capacity"], 3)
+            self.assertEqual(usage["remaining_count"], 3)
+
+            result = await service.validate_code("WELF-CODE-001", session)
+            self.assertTrue(result["success"])
+            self.assertTrue(result["valid"])
+            self.assertEqual(result["redemption_code"]["limit"], 3)
+            self.assertEqual(result["redemption_code"]["used_count"], 2)
+
+    async def test_virtual_welfare_code_handles_concurrent_redemptions_up_to_capacity(self):
+        async with self.session_factory() as session:
+            welfare_team = Team(
+                id=61,
+                email="welfare-owner-61@example.com",
+                access_token_encrypted="token-61",
+                account_id="acct-61",
+                team_name="Welfare Concurrent Team",
+                current_members=0,
+                max_members=5,
+                status="active",
+                pool_type="welfare",
+            )
+            session.add_all([
+                welfare_team,
+            ])
+            await session.commit()
+            settings_service.clear_cache()
+            await settings_service.update_setting(session, "welfare_common_code", "WELF-CONCURRENT-001")
+
+            service = RedeemFlowService()
+            service.team_service = StubTeamService()
+            service.chatgpt_service = StubChatGPTService(
+                {
+                    "acct-61": [
+                        {"success": True, "data": {"account_invites": [{"email": f"user{i}@example.com"}]}}
+                        for i in range(6)
+                    ]
+                }
+            )
+
+            async def redeem(email):
+                async with self.session_factory() as inner_session:
+                    with patch.object(service, "_background_verify_sync", new=self._noop_async), \
+                         patch.object(notification_service, "check_and_notify_low_stock", new=self._noop_async):
+                        return await service.redeem_and_join_team(
+                            email=email,
+                            code="WELF-CONCURRENT-001",
+                            team_id=None,
+                            db_session=inner_session,
+                        )
+
+            results = await asyncio.gather(*[
+                redeem(f"user{i}@example.com")
+                for i in range(6)
+            ])
+
+            success_count = sum(1 for result in results if result["success"])
+            failure_count = sum(1 for result in results if not result["success"])
+            self.assertEqual(success_count, 5)
+            self.assertEqual(failure_count, 1)
+
+            async with self.session_factory() as verify_session:
+                stored_team = await verify_session.get(Team, 61)
+                self.assertEqual(stored_team.current_members, 5)
+                self.assertEqual(stored_team.status, "full")
+
+                records = (
+                    await verify_session.execute(
+                        select(RedemptionRecord).where(RedemptionRecord.code == "WELF-CONCURRENT-001")
+                    )
+                ).scalars().all()
+                self.assertEqual(len(records), 5)
+
+                usage = await RedemptionService().get_virtual_welfare_code_usage(
+                    verify_session,
+                    welfare_code="WELF-CONCURRENT-001",
+                )
+                self.assertEqual(usage["remaining_count"], 0)


### PR DESCRIPTION
### Motivation
- Correct mismatches in virtual welfare usage accounting and prevent double-decrement of remaining capacity when reporting or validating welfare codes.
- Make warranty checks safer by avoiding automatic deletion of suspected-orphan records and by failing expired warranty codes earlier in the validation flow.
- Ensure team seat reservation and status updates rollback consistently on API errors and prevent negative member counts.
- Restrict the device-auth enabling endpoint to administrators to avoid unauthorized actions.

### Description
- Updated `get_virtual_welfare_code_usage` to include `remaining_count` and switched admin UI and `validate_code` to use `remaining_count` instead of the previous `usable_capacity` interpretation.
- Added an early warranty-expiry check in `RedemptionService.validate_code` to mark used warranty codes as `expired` and reject them with reason `质保已过期`.
- Hardened seat rollback logic in `RedeemFlowService` to avoid negative `current_members`, to recompute `status` (`full`/`expired`/`active`) correctly after failures, and to restore state on errors.
- Modified `WarrantyService.check_warranty_status` to stop auto-deleting records when remote sync shows a missing member, instead marking entries as `suspected_inconsistent` and preserving original records; added messaging and a `suspected_inconsistent_count` path.
- Changed `validate_warranty_reuse` to disallow email handoff by returning `can_reuse: False` with a localized reason that reuse is limited to the original email.
- Simplified the warranty route `POST /warranty/enable-device-auth` to be admin-only by adding the `require_admin` dependency and delegating to `team_service.enable_device_code_auth` without attempting local record deletion/verification in the route.
- Added/updated unit tests in `tests/test_redeem_flow.py` covering expired warranty validation, warranty reuse/email-handoff rejection, preservation of records when sync misses a member, seat rollback behavior after full errors, virtual welfare usage accounting, and concurrent welfare redemptions up to capacity.

### Testing
- Ran the modified test module with `pytest tests/test_redeem_flow.py` and all new and existing tests in that file passed.
- Exercised `RedemptionService.validate_code` and `get_virtual_welfare_code_usage` via unit tests that assert `remaining_count` and virtual welfare behavior under concurrent redemptions, which succeeded.
- Verified warranty-related unit tests (`check_warranty_status` and `validate_warranty_reuse`) passed, confirming non-destructive handling of suspected-orphan records and rejection of email handoffs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bf726bce588320aa92f61431b337a1)