### PR TITLE
Add admin scan & cleanup for invalid redemption codes and sync status updates

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -120,6 +120,11 @@ class BulkCodeUpdateRequest(BaseModel):
     warranty_days: Optional[int] = Field(None, description="质保天数")
 
 
+class InvalidCodeCleanupRequest(BaseModel):
+    """无效兑换码清理请求"""
+    codes: List[str] = Field(..., description="待清理的无效兑换码列表")
+
+
 class BulkActionRequest(BaseModel):
     """批量操作请求"""
     ids: List[int] = Field(..., description="Team ID 列表")
@@ -1271,6 +1276,47 @@ async def delete_code(
                 "success": False,
                 "error": "删除失败，请稍后重试"
             }
+        )
+
+
+@router.get("/codes/invalid/scan")
+async def scan_invalid_codes(
+    db: AsyncSession = Depends(get_db),
+    current_user: dict = Depends(require_admin)
+):
+    """扫描可安全清理的无效兑换码。"""
+    try:
+        result = await redemption_service.get_invalid_code_candidates(db, pool_type="normal")
+        status_code = status.HTTP_200_OK if result["success"] else status.HTTP_400_BAD_REQUEST
+        return JSONResponse(status_code=status_code, content=result)
+    except Exception:
+        logger.exception("扫描无效兑换码失败")
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content={"success": False, "error": "扫描无效兑换码失败，请稍后重试"}
+        )
+
+
+@router.post("/codes/invalid/cleanup")
+async def cleanup_invalid_codes(
+    cleanup_data: InvalidCodeCleanupRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: dict = Depends(require_admin)
+):
+    """批量清理扫描出的无效兑换码。"""
+    try:
+        result = await redemption_service.cleanup_invalid_codes(
+            cleanup_data.codes,
+            db,
+            pool_type="normal"
+        )
+        status_code = status.HTTP_200_OK if result["success"] else status.HTTP_400_BAD_REQUEST
+        return JSONResponse(status_code=status_code, content=result)
+    except Exception:
+        logger.exception("清理无效兑换码失败")
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content={"success": False, "error": "清理无效兑换码失败，请稍后重试"}
         )
 
 

--- a/app/services/redemption.py
+++ b/app/services/redemption.py
@@ -65,6 +65,238 @@ class RedemptionService:
         redemption_code.used_at = None
         redemption_code.warranty_expires_at = None
 
+    @staticmethod
+    def _sync_code_status_fields(redemption_code: RedemptionCode) -> bool:
+        """按当前时间同步兑换码状态，避免状态被错误地长期停留在过期态。"""
+        now = get_now()
+        original_status = redemption_code.status
+
+        if redemption_code.used_at:
+            if (
+                redemption_code.has_warranty
+                and redemption_code.warranty_expires_at
+                and redemption_code.warranty_expires_at < now
+            ):
+                redemption_code.status = "expired"
+            else:
+                redemption_code.status = "used"
+            return redemption_code.status != original_status
+
+        if redemption_code.expires_at:
+            redemption_code.status = "expired" if redemption_code.expires_at < now else "unused"
+        elif redemption_code.status not in {"unused", "used"}:
+            redemption_code.status = "unused"
+
+        return redemption_code.status != original_status
+
+    async def _sync_pool_code_statuses(
+        self,
+        db_session: AsyncSession,
+        pool_type: Optional[str] = None
+    ) -> bool:
+        """批量同步指定兑换池中的兑换码状态。"""
+        stmt = select(RedemptionCode)
+        if pool_type:
+            stmt = stmt.where(RedemptionCode.pool_type == pool_type)
+
+        result = await db_session.execute(stmt)
+        all_codes = result.scalars().all()
+
+        status_changed = False
+        for code in all_codes:
+            status_changed = self._sync_code_status_fields(code) or status_changed
+
+        if status_changed:
+            await db_session.commit()
+
+        return status_changed
+
+    async def _can_cleanup_expired_code_records(
+        self,
+        redemption_code: RedemptionCode,
+        db_session: AsyncSession
+    ) -> bool:
+        """判断是否允许清理失效兑换码的历史记录并彻底删除。"""
+        self._sync_code_status_fields(redemption_code)
+        if redemption_code.status != "expired":
+            if redemption_code.has_warranty or redemption_code.expires_at or not redemption_code.used_at:
+                return False
+        if not redemption_code.has_warranty and not redemption_code.expires_at and not redemption_code.used_at:
+            return False
+
+        record_team_result = await db_session.execute(
+            select(RedemptionRecord.team_id).where(RedemptionRecord.code == redemption_code.code)
+        )
+        team_ids = {team_id for team_id in record_team_result.scalars().all() if team_id is not None}
+        if not team_ids:
+            return True
+
+        teams_result = await db_session.execute(
+            select(Team).where(Team.id.in_(team_ids))
+        )
+        teams = {team.id: team for team in teams_result.scalars().all()}
+
+        unavailable_statuses = {"expired", "error", "banned"}
+        for team_id in team_ids:
+            team = teams.get(team_id)
+            if not team:
+                continue
+            if (team.status or "").lower() not in unavailable_statuses:
+                return False
+
+        return True
+
+    @staticmethod
+    def _get_cleanup_reference_time(redemption_code: RedemptionCode) -> Optional[datetime]:
+        """获取用于判断历史脏数据冷却期的参考时间。"""
+        if redemption_code.warranty_expires_at:
+            return redemption_code.warranty_expires_at
+        if redemption_code.expires_at:
+            return redemption_code.expires_at
+        if redemption_code.used_at and not redemption_code.has_warranty:
+            # 长期有效但无质保的兑换码，一旦被使用且关联 Team 不可用，就应按“使用时间”进入无效清理冷却期。
+            return redemption_code.used_at
+        return None
+
+    async def get_invalid_code_candidates(
+        self,
+        db_session: AsyncSession,
+        pool_type: Optional[str] = "normal"
+    ) -> Dict[str, Any]:
+        """扫描可安全清理的无效兑换码。"""
+        try:
+            await self._sync_pool_code_statuses(db_session, pool_type)
+
+            stmt = select(RedemptionCode)
+            if pool_type:
+                stmt = stmt.where(RedemptionCode.pool_type == pool_type)
+
+            result = await db_session.execute(stmt.order_by(RedemptionCode.created_at.desc()))
+            codes = result.scalars().all()
+
+            cooldown_threshold = get_now() - timedelta(days=30)
+            candidates: List[Dict[str, Any]] = []
+
+            for code in codes:
+                record_count_result = await db_session.execute(
+                    select(func.count(RedemptionRecord.id)).where(RedemptionRecord.code == code.code)
+                )
+                record_count = int(record_count_result.scalar() or 0)
+                is_deleted_team_orphan = (
+                    record_count == 0
+                    and code.used_at is not None
+                    and code.used_team_id is None
+                )
+                if record_count <= 0 and not is_deleted_team_orphan:
+                    continue
+
+                cleanup_reference_time = self._get_cleanup_reference_time(code)
+                if not cleanup_reference_time or cleanup_reference_time > cooldown_threshold:
+                    continue
+
+                if code.has_warranty or code.expires_at:
+                    if code.status != "expired":
+                        continue
+                elif not code.used_at or code.has_warranty:
+                    continue
+
+                if record_count > 0 and not await self._can_cleanup_expired_code_records(code, db_session):
+                    continue
+
+                if record_count > 0:
+                    record_team_result = await db_session.execute(
+                        select(RedemptionRecord.team_id).where(RedemptionRecord.code == code.code)
+                    )
+                    linked_team_ids = sorted({team_id for team_id in record_team_result.scalars().all() if team_id is not None})
+
+                    teams_result = await db_session.execute(
+                        select(Team).where(Team.id.in_(linked_team_ids))
+                    ) if linked_team_ids else None
+                    teams = {
+                        team.id: (team.status or "unknown")
+                        for team in (teams_result.scalars().all() if teams_result else [])
+                    }
+
+                    team_status_summary = [
+                        {
+                            "team_id": team_id,
+                            "status": teams.get(team_id, "deleted")
+                        }
+                        for team_id in linked_team_ids
+                    ]
+                else:
+                    team_status_summary = [{"team_id": "-", "status": "deleted"}]
+
+                candidates.append({
+                    "code": code.code,
+                    "status": code.status,
+                    "record_count": record_count,
+                    "expired_at": cleanup_reference_time.isoformat() if cleanup_reference_time else None,
+                    "team_statuses": team_status_summary,
+                    "reason": "无效兑换码"
+                })
+
+            return {
+                "success": True,
+                "codes": candidates,
+                "total": len(candidates),
+                "error": None
+            }
+        except Exception:
+            logger.exception("扫描无效兑换码失败")
+            return {
+                "success": False,
+                "codes": [],
+                "total": 0,
+                "error": "扫描无效兑换码失败，请稍后重试"
+            }
+
+    async def cleanup_invalid_codes(
+        self,
+        codes: List[str],
+        db_session: AsyncSession,
+        pool_type: Optional[str] = "normal"
+    ) -> Dict[str, Any]:
+        """批量清理通过无效扫描的兑换码。"""
+        try:
+            if not codes:
+                return {"success": False, "error": "请选择需要清理的兑换码"}
+
+            scan_result = await self.get_invalid_code_candidates(db_session, pool_type=pool_type)
+            if not scan_result["success"]:
+                return {"success": False, "error": scan_result["error"]}
+
+            candidate_codes = {item["code"] for item in scan_result["codes"]}
+            requested_codes = [code for code in codes if code in candidate_codes]
+            rejected_codes = [code for code in codes if code not in candidate_codes]
+
+            if not requested_codes:
+                return {"success": False, "error": "所选兑换码不满足无效清理条件，已拒绝删除"}
+
+            await db_session.execute(
+                delete(RedemptionRecord).where(RedemptionRecord.code.in_(requested_codes))
+            )
+            await db_session.execute(
+                delete(RedemptionCode).where(RedemptionCode.code.in_(requested_codes))
+            )
+            await db_session.commit()
+
+            message = f"已清理 {len(requested_codes)} 个无效兑换码"
+            if rejected_codes:
+                message += f"，另有 {len(rejected_codes)} 个因条件不满足被跳过"
+
+            return {
+                "success": True,
+                "message": message,
+                "deleted_codes": requested_codes,
+                "skipped_codes": rejected_codes,
+                "error": None
+            }
+        except Exception:
+            await db_session.rollback()
+            logger.exception("批量清理无效兑换码失败")
+            return {"success": False, "error": "批量清理无效兑换码失败，请稍后重试"}
+
 
     async def ensure_virtual_welfare_shadow_code(
         self,
@@ -525,13 +757,12 @@ class RedemptionService:
                         "error": None
                     }
 
+            status_changed = self._sync_code_status_fields(redemption_code)
+            if status_changed:
+                await db_session.flush()
+
             # 4. 检查质保是否已过期（针对已使用的质保码）
-            if (
-                redemption_code.has_warranty
-                and redemption_code.status == "used"
-                and redemption_code.warranty_expires_at
-                and redemption_code.warranty_expires_at < get_now()
-            ):
+            if redemption_code.status == "expired" and redemption_code.used_at:
                 redemption_code.status = "expired"
                 return {
                     "success": True,
@@ -542,20 +773,14 @@ class RedemptionService:
                 }
 
             # 5. 检查是否过期 (仅针对未使用的兑换码执行首次激活截止时间检查)
-            if redemption_code.status == "unused" and redemption_code.expires_at:
-                if redemption_code.expires_at < get_now():
-                    # 更新状态为 expired
-                    redemption_code.status = "expired"
-                    # 不在服务层内部 commit，让调用方决定事务边界
-                    # await db_session.commit() 
-
-                    return {
-                        "success": True,
-                        "valid": False,
-                        "reason": "兑换码已过期 (超过首次兑换截止时间)",
-                        "redemption_code": None,
-                        "error": None
-                    }
+            if redemption_code.status == "expired" and not redemption_code.used_at:
+                return {
+                    "success": True,
+                    "valid": False,
+                    "reason": "兑换码已过期 (超过首次兑换截止时间)",
+                    "redemption_code": None,
+                    "error": None
+                }
 
             # 6. 验证通过
             return {
@@ -686,6 +911,8 @@ class RedemptionService:
             结果字典,包含 success, codes, total, total_pages, current_page, error
         """
         try:
+            await self._sync_pool_code_statuses(db_session, pool_type)
+
             # 1. 构建基础查询
             count_stmt = select(func.count(RedemptionCode.id))
             stmt = select(RedemptionCode).order_by(RedemptionCode.created_at.desc())
@@ -728,6 +955,19 @@ class RedemptionService:
             result = await db_session.execute(stmt)
             codes = result.scalars().all()
 
+            record_counts: Dict[str, int] = {}
+            if codes:
+                code_values = [code.code for code in codes]
+                record_count_result = await db_session.execute(
+                    select(RedemptionRecord.code, func.count(RedemptionRecord.id))
+                    .where(RedemptionRecord.code.in_(code_values))
+                    .group_by(RedemptionRecord.code)
+                )
+                record_counts = {
+                    record_code: int(record_total or 0)
+                    for record_code, record_total in record_count_result.all()
+                }
+
             # 构建返回数据
             code_list = []
             for code in codes:
@@ -742,7 +982,8 @@ class RedemptionService:
                     "used_at": code.used_at.isoformat() if code.used_at else None,
                     "has_warranty": code.has_warranty,
                     "warranty_days": code.warranty_days,
-                    "warranty_expires_at": code.warranty_expires_at.isoformat() if code.warranty_expires_at else None
+                    "warranty_expires_at": code.warranty_expires_at.isoformat() if code.warranty_expires_at else None,
+                    "can_delete": record_counts.get(code.code, 0) == 0
                 })
 
             logger.info(f"获取所有兑换码成功: 第 {page} 页, 共 {len(code_list)} 个 / 总数 {total}")
@@ -977,6 +1218,8 @@ class RedemptionService:
                     "error": f"兑换码 {code} 不存在"
                 }
 
+            self._sync_code_status_fields(redemption_code)
+
             # 已产生历史记录的兑换码不能直接删除，否则会破坏使用记录完整性。
             record_count_result = await db_session.execute(
                 select(func.count(RedemptionRecord.id)).where(RedemptionRecord.code == code)
@@ -986,7 +1229,7 @@ class RedemptionService:
                 return {
                     "success": False,
                     "message": None,
-                    "error": f"兑换码 {code} 已有 {record_count} 条使用记录，无法直接删除；请先撤回相关记录"
+                    "error": f"兑换码 {code} 已有 {record_count} 条关联记录，无法直接删除"
                 }
 
             # 删除兑换码
@@ -1161,6 +1404,8 @@ class RedemptionService:
             统计字典, 包含 total, unused, used, expired
         """
         try:
+            await self._sync_pool_code_statuses(db_session, pool_type)
+
             # 使用 SQL 聚合统计各状态数量
             stmt = select(
                 RedemptionCode.status,

--- a/app/templates/admin/codes/index.html
+++ b/app/templates/admin/codes/index.html
@@ -41,22 +41,22 @@
 
 <!-- 操作栏 -->
 <div class="content-section">
-    <div class="section-header">
-        <div class="header-group">
-            <div class="filter-tabs">
-                <button onclick="filterByStatus('')" class="filter-tab {% if not status_filter %}active{% endif %}"
-                    id="filter-all">全部</button>
-                <button onclick="filterByStatus('unused')"
-                    class="filter-tab {% if status_filter == 'unused' %}active{% endif %}"
-                    id="filter-unused">未使用</button>
-                <button onclick="filterByStatus('used')"
-                    class="filter-tab {% if status_filter == 'used' %}active{% endif %}" id="filter-used">已使用</button>
-                <button onclick="filterByStatus('expired')"
-                    class="filter-tab {% if status_filter == 'expired' %}active{% endif %}"
-                    id="filter-expired">已过期</button>
-            </div>
+    <div class="section-header codes-toolbar">
+        <div class="filter-tabs">
+            <button onclick="filterByStatus('')" class="filter-tab {% if not status_filter %}active{% endif %}"
+                id="filter-all">全部</button>
+            <button onclick="filterByStatus('unused')"
+                class="filter-tab {% if status_filter == 'unused' %}active{% endif %}"
+                id="filter-unused">未使用</button>
+            <button onclick="filterByStatus('used')"
+                class="filter-tab {% if status_filter == 'used' %}active{% endif %}" id="filter-used">已使用</button>
+            <button onclick="filterByStatus('expired')"
+                class="filter-tab {% if status_filter == 'expired' %}active{% endif %}"
+                id="filter-expired">已过期</button>
+        </div>
 
-            <form action="/admin/codes" method="get" class="search-form">
+        <div class="codes-toolbar-actions">
+            <form action="/admin/codes" method="get" class="search-form codes-search-form">
                 <div class="input-group-clean">
                     <i data-lucide="search" style="width: 14px; height: 14px;"></i>
                     <input type="text" name="search" value="{{ search or '' }}" placeholder="搜索兑换码..."
@@ -68,23 +68,26 @@
                     {% endif %}
                 </div>
             </form>
-        </div>
 
-        <div class="header-actions">
-            <div class="dropdown-wrapper">
-                <button class="btn btn-secondary dropdown-toggle" onclick="toggleDropdown('columnToggleDropdown')">
-                    <i data-lucide="columns" style="width: 16px; height: 16px;"></i> 列设置
-                </button>
-                <div id="columnToggleDropdown" class="dropdown-menu">
-                    <!-- Column checkboxes will be generated here -->
+            <div class="header-actions codes-header-actions">
+                <div class="dropdown-wrapper">
+                    <button class="btn btn-secondary btn-sm dropdown-toggle" onclick="toggleDropdown('columnToggleDropdown')">
+                        <i data-lucide="columns" style="width: 16px; height: 16px;"></i> 列设置
+                    </button>
+                    <div id="columnToggleDropdown" class="dropdown-menu">
+                        <!-- Column checkboxes will be generated here -->
+                    </div>
                 </div>
+                <button onclick="scanInvalidCodes()" class="btn btn-secondary btn-sm">
+                    <i data-lucide="shield-alert" style="width: 16px; height: 16px;"></i> 扫描无效兑换码
+                </button>
+                <button onclick="showModal('generateCodeModal')" class="btn btn-primary btn-sm">
+                    <i data-lucide="plus-circle" style="width: 16px; height: 16px;"></i> 生成兑换码
+                </button>
+                <button onclick="exportCodes()" class="btn btn-secondary btn-sm">
+                    <i data-lucide="download" style="width: 16px; height: 16px;"></i> 导出
+                </button>
             </div>
-            <button onclick="showModal('generateCodeModal')" class="btn btn-primary">
-                <i data-lucide="plus-circle" style="width: 16px; height: 16px;"></i> 生成兑换码
-            </button>
-            <button onclick="exportCodes()" class="btn btn-secondary">
-                <i data-lucide="download" style="width: 16px; height: 16px;"></i> 导出
-            </button>
         </div>
     </div>
 </div>
@@ -164,12 +167,10 @@
                                 class="btn btn-sm btn-icon btn-minimal btn-info" title="编辑">
                                 <i data-lucide="edit-3" style="width: 14px; height: 14px;"></i>
                             </button>
-                            {% if code.status == 'unused' %}
                             <button onclick='deleteCode({{ code.code|tojson }})'
                                 class="btn btn-sm btn-icon btn-minimal btn-danger" title="删除">
                                 <i data-lucide="trash-2" style="width: 14px; height: 14px;"></i>
                             </button>
-                            {% endif %}
                         </div>
                     </td>
                 </tr>
@@ -353,10 +354,123 @@
         </div>
     </div>
 </div>
+
+<!-- 无效兑换码扫描结果 -->
+<div id="invalidCodesModal" class="modal-overlay">
+    <div class="modal" style="max-width: 760px;">
+        <div class="modal-header">
+            <h3>无效兑换码扫描结果</h3>
+            <button class="modal-close" onclick="hideModal('invalidCodesModal')">&times;</button>
+        </div>
+        <div class="modal-body">
+            <div class="alert alert-info" style="margin-bottom: 1rem;">
+                扫描可安全清理的无效兑换码。
+            </div>
+            <div id="invalidCodesEmptyState" class="empty-state" style="display: none; padding: 1rem 0;">
+                <p>当前没有扫描到可安全清理的无效兑换码。</p>
+            </div>
+            <div id="invalidCodesTableWrapper" style="display: none;">
+                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; gap: 1rem; flex-wrap: wrap;">
+                    <div>共扫描到 <strong id="invalidCodesCount">0</strong> 个可清理兑换码</div>
+                </div>
+                <div class="table-container">
+                    <table class="data-table">
+                        <thead>
+                            <tr>
+                                <th style="width: 40px;"><input type="checkbox" id="selectAllInvalidCodes" style="width: auto; margin: 0;" onclick="toggleSelectAllInvalidCodes(this)"></th>
+                                <th>兑换码</th>
+                                <th>过期参考时间</th>
+                                <th>关联记录数</th>
+                                <th>关联 Team 状态</th>
+                                <th>说明</th>
+                            </tr>
+                        </thead>
+                        <tbody id="invalidCodesTableBody"></tbody>
+                    </table>
+                </div>
+                <div id="invalidCleanupBar" class="invalid-cleanup-bar" style="display: none;">
+                    <div>已选择 <strong id="invalidCleanupSelectedCount">0</strong> 个无效兑换码</div>
+                    <button onclick="cleanupInvalidCodes()" class="btn btn-danger">
+                        <i data-lucide="trash-2" style="width: 16px; height: 16px;"></i> 确认删除
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- 删除兑换码确认模态框 -->
+<div id="deleteCodeModal" class="modal-overlay">
+    <div class="modal">
+        <div class="modal-header">
+            <h3>确认删除兑换码</h3>
+            <button class="modal-close" onclick="hideModal('deleteCodeModal')">&times;</button>
+        </div>
+        <div class="modal-body">
+            <div class="alert alert-warning" style="margin-bottom: 1rem;">
+                所有兑换码都支持手动发起删除，但系统只会真正删除<strong>没有任何关联记录</strong>的兑换码。已使用或仍有关联记录的兑换码会被明确拦截，防止误删。
+            </div>
+            <form id="deleteCodeForm" onsubmit="handleDeleteCode(event)">
+                <input type="hidden" id="delete-code-value">
+                <div class="form-group">
+                    <label>待删除兑换码</label>
+                    <input type="text" id="delete-code-display" class="form-control" readonly
+                        style="background: rgba(0,0,0,0.05);">
+                </div>
+                <div class="form-group">
+                    <label>请输入完整兑换码确认删除</label>
+                    <input type="text" id="delete-code-confirm" class="form-control"
+                        placeholder="请输入上方完整兑换码" autocomplete="off" required>
+                    <small class="form-text">如果该兑换码存在任何关联记录，系统会直接拒绝删除；历史脏数据请使用上方“扫描无效兑换码”功能单独处理。</small>
+                </div>
+                <button type="submit" class="btn btn-danger" style="margin-top: 1rem;">确认删除</button>
+            </form>
+        </div>
+    </div>
+</div>
 {% endblock %}
 
 {% block extra_css %}
 <style>
+    .codes-toolbar {
+        align-items: center;
+        justify-content: space-between;
+        flex-wrap: nowrap;
+        gap: 1rem;
+    }
+
+    .codes-toolbar-actions {
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 0.5rem;
+        flex: 0 1 auto;
+        flex-wrap: nowrap;
+        min-width: 0;
+    }
+
+    .codes-search-form {
+        margin: 0;
+        flex: 0 0 auto;
+    }
+
+    .codes-search-form .input-group-clean {
+        width: 240px;
+        min-width: 240px;
+    }
+
+    .codes-header-actions {
+        flex-wrap: nowrap;
+        justify-content: flex-end;
+        gap: 0.5rem;
+    }
+
+    .codes-header-actions .btn {
+        white-space: nowrap;
+        padding: 0.6rem 0.8rem;
+        font-size: 0.875rem;
+    }
+
     .bulk-action-bar {
         position: fixed;
         bottom: 2rem;
@@ -395,11 +509,58 @@
         display: flex;
         gap: 0.5rem;
     }
+
+    .invalid-cleanup-bar {
+        position: sticky;
+        bottom: 0;
+        margin-top: 1rem;
+        padding: 1rem;
+        border-top: 1px solid var(--border-color);
+        background: rgba(255, 255, 255, 0.96);
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1rem;
+        backdrop-filter: blur(8px);
+    }
+
+    @media (max-width: 1240px) {
+        .codes-toolbar {
+            align-items: stretch;
+            flex-wrap: wrap;
+        }
+
+        .codes-toolbar-actions {
+            width: 100%;
+            justify-content: space-between;
+            flex-wrap: wrap;
+        }
+
+        .codes-search-form {
+            flex: 1 1 240px;
+        }
+
+        .codes-search-form .input-group-clean {
+            min-width: 0;
+            width: 100%;
+        }
+    }
+
+    @media (max-width: 768px) {
+        .codes-toolbar-actions,
+        .codes-header-actions {
+            width: 100%;
+            justify-content: flex-start;
+            flex-wrap: wrap;
+        }
+    }
 </style>
 {% endblock %}
 
 {% block extra_js %}
 <script>
+    let scannedInvalidCodes = [];
+
     document.addEventListener('DOMContentLoaded', () => {
         // Init Column Toggler
         initColumnToggler('.data-table', 'codes_list_columns');
@@ -574,8 +735,20 @@
     }
 
     // 删除兑换码
-    async function deleteCode(code) {
-        if (!confirm(`确定要删除兑换码 ${code} 吗?`)) {
+    function deleteCode(code) {
+        document.getElementById('delete-code-value').value = code;
+        document.getElementById('delete-code-display').value = code;
+        document.getElementById('delete-code-confirm').value = '';
+        showModal('deleteCodeModal');
+    }
+
+    async function handleDeleteCode(event) {
+        event.preventDefault();
+        const code = document.getElementById('delete-code-value').value;
+        const confirmValue = document.getElementById('delete-code-confirm').value.trim();
+
+        if (confirmValue !== code) {
+            showToast('输入的兑换码不匹配，请重新确认', 'error');
             return;
         }
 
@@ -590,6 +763,7 @@
             const result = await response.json();
 
             if (response.ok && result.success) {
+                hideModal('deleteCodeModal');
                 showToast('删除成功', 'success');
                 // 刷新页面
                 setTimeout(() => {
@@ -597,6 +771,113 @@
                 }, 1000);
             } else {
                 showToast(result.error || '删除失败', 'error');
+            }
+        } catch (error) {
+            showToast('网络错误', 'error');
+        }
+    }
+
+    function renderInvalidCodes(codes) {
+        scannedInvalidCodes = codes || [];
+        const emptyState = document.getElementById('invalidCodesEmptyState');
+        const tableWrapper = document.getElementById('invalidCodesTableWrapper');
+        const tableBody = document.getElementById('invalidCodesTableBody');
+        const countEl = document.getElementById('invalidCodesCount');
+        const selectAll = document.getElementById('selectAllInvalidCodes');
+        const cleanupBar = document.getElementById('invalidCleanupBar');
+        const cleanupSelectedCount = document.getElementById('invalidCleanupSelectedCount');
+
+        if (!tableBody || !emptyState || !tableWrapper || !countEl || !selectAll || !cleanupBar || !cleanupSelectedCount) return;
+
+        tableBody.innerHTML = '';
+        countEl.innerText = scannedInvalidCodes.length;
+        selectAll.checked = false;
+        cleanupBar.style.display = 'none';
+        cleanupSelectedCount.innerText = '0';
+
+        if (!scannedInvalidCodes.length) {
+            emptyState.style.display = 'block';
+            tableWrapper.style.display = 'none';
+            return;
+        }
+
+        emptyState.style.display = 'none';
+        tableWrapper.style.display = 'block';
+
+        scannedInvalidCodes.forEach((item) => {
+            const tr = document.createElement('tr');
+            const teamStatusText = (item.team_statuses || []).map((team) => `#${team.team_id}: ${team.status}`).join('，') || 'Team 已删除';
+            tr.innerHTML = `
+                <td><input type="checkbox" class="invalid-code-checkbox" value="${escapeHtml(item.code)}" style="width: auto; margin: 0;" onchange="updateInvalidCleanupSelection()"></td>
+                <td><code>${escapeHtml(item.code)}</code></td>
+                <td>${escapeHtml(formatDateTime(item.expired_at))}</td>
+                <td>${escapeHtml(item.record_count)}</td>
+                <td>${escapeHtml(teamStatusText)}</td>
+                <td>${escapeHtml(item.reason || '-')}</td>
+            `;
+            tableBody.appendChild(tr);
+        });
+    }
+
+    async function scanInvalidCodes() {
+        try {
+            const response = await fetch('/admin/codes/invalid/scan');
+            const result = await response.json();
+
+            if (response.ok && result.success) {
+                renderInvalidCodes(result.codes || []);
+                showModal('invalidCodesModal');
+                if (window.lucide) {
+                    lucide.createIcons();
+                }
+            } else {
+                showToast(result.error || '扫描失败', 'error');
+            }
+        } catch (error) {
+            showToast('网络错误', 'error');
+        }
+    }
+
+    function toggleSelectAllInvalidCodes(checkbox) {
+        document.querySelectorAll('.invalid-code-checkbox').forEach((item) => {
+            item.checked = checkbox.checked;
+        });
+        updateInvalidCleanupSelection();
+    }
+
+    function updateInvalidCleanupSelection() {
+        const selected = document.querySelectorAll('.invalid-code-checkbox:checked');
+        const cleanupBar = document.getElementById('invalidCleanupBar');
+        const cleanupSelectedCount = document.getElementById('invalidCleanupSelectedCount');
+        if (!cleanupBar || !cleanupSelectedCount) return;
+
+        cleanupSelectedCount.innerText = selected.length;
+        cleanupBar.style.display = selected.length > 0 ? 'flex' : 'none';
+    }
+
+    async function cleanupInvalidCodes() {
+        const selected = Array.from(document.querySelectorAll('.invalid-code-checkbox:checked')).map((item) => item.value);
+        if (!selected.length) {
+            showToast('请先选择需要清理的兑换码', 'error');
+            return;
+        }
+
+        try {
+            const response = await fetch('/admin/codes/invalid/cleanup', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ codes: selected })
+            });
+
+            const result = await response.json();
+            if (response.ok && result.success) {
+                hideModal('invalidCodesModal');
+                showToast(result.message || '清理成功', 'success');
+                setTimeout(() => window.location.reload(), 1000);
+            } else {
+                showToast(result.error || '清理失败', 'error');
             }
         } catch (error) {
             showToast('网络错误', 'error');

--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -87,6 +87,56 @@
             font-size: 1.5rem;
         }
     }
+
+    .team-toolbar {
+        flex-wrap: nowrap;
+        align-items: center;
+        gap: 1rem;
+    }
+
+    .team-toolbar .header-group {
+        flex: 1;
+        min-width: 0;
+        justify-content: flex-end;
+        flex-wrap: nowrap;
+        gap: 0.75rem;
+    }
+
+    .team-toolbar .search-form {
+        margin: 0;
+        flex: 0 0 auto;
+    }
+
+    .team-toolbar .search-form .input-group-clean {
+        width: 300px;
+        min-width: 300px;
+    }
+
+    .team-toolbar .btn {
+        white-space: nowrap;
+    }
+
+    @media (max-width: 1240px) {
+        .team-toolbar {
+            flex-wrap: wrap;
+            align-items: stretch;
+        }
+
+        .team-toolbar .header-group {
+            width: 100%;
+            justify-content: flex-start;
+            flex-wrap: wrap;
+        }
+
+        .team-toolbar .search-form {
+            flex: 1 1 260px;
+        }
+
+        .team-toolbar .search-form .input-group-clean {
+            width: 100%;
+            min-width: 0;
+        }
+    }
 </style>
 {% endblock %}
 
@@ -162,7 +212,7 @@
 
 <!-- Team 列表 -->
 <div class="content-section">
-    <div class="section-header">
+    <div class="section-header team-toolbar">
         <h3>{% if active_page == "welfare" %}福利 Team 列表{% else %}Team 列表{% endif %}</h3>
         <div class="header-group">
             <!-- 批量操作 -->


### PR DESCRIPTION
### Motivation
- Provide administrators a safe way to identify and remove truly invalid/orphaned redemption codes and avoid accidental deletion of codes with historical records. 
- Ensure code `status` fields reflect current time-based state so UI and cleanup logic operate on up-to-date information. 
- Improve admin UX for code management by adding scanning, bulk cleanup and a stricter delete confirmation flow in the admin UI. 

### Description
- Service layer: added status-sync helpers and cleanup flow including `
_sync_code_status_fields`, `
_sync_pool_code_statuses`, `
_can_cleanup_expired_code_records`, `
_get_cleanup_reference_time`, `get_invalid_code_candidates` and `cleanup_invalid_codes` to `app/services/redemption.py` so expired/used/warranty logic is reconciled before operations. 
- Behavior changes: validation and listing paths now call status sync (used by `get_all_codes`, `get_stats` and validation flow) and `get_all_codes` now includes per-code `can_delete` based on associated record counts. 
- Admin API & models: added `InvalidCodeCleanupRequest` and two new endpoints `GET /admin/codes/invalid/scan` and `POST /admin/codes/invalid/cleanup` in `app/routes/admin.py` to expose scanning and cleanup actions to admins. 
- UI/template changes: updated `app/templates/admin/codes/index.html` and `app/templates/admin/index.html` to add toolbar buttons for scanning, a scanning results modal with selection and bulk cleanup, a stricter delete confirmation modal, responsive toolbar CSS and client-side JS functions `scanInvalidCodes`, `renderInvalidCodes`, `cleanupInvalidCodes` and form handlers for safe deletion. 

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bfbd790c008320a7532f1a78bfbc51)