### PR TITLE
Render status filter dropdown as floating overlay

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -651,6 +651,16 @@ body.admin-theme .toast {
     display: block;
 }
 
+.dropdown-menu-floating {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: auto;
+    width: 260px;
+    max-width: calc(100vw - 2rem);
+    z-index: 1200;
+}
+
 .dropdown-header {
     padding: 0.5rem 0.75rem;
     font-size: 0.75rem;

--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -243,7 +243,7 @@
                         {% endif %}
                     </span>
                 </button>
-                <div id="statusFilterDropdown" class="dropdown-menu">
+                <div id="statusFilterDropdown" class="dropdown-menu dropdown-menu-floating">
                     <div class="dropdown-header">选择状态</div>
                     <div class="dropdown-item" onclick="filterByStatus('')">
                         <span class="text-muted">所有状态</span>
@@ -1027,15 +1027,50 @@
         });
     }
 
+    function positionFloatingDropdown(menu) {
+        if (!menu || !menu.classList.contains('dropdown-menu-floating')) return;
+
+        const wrapper = menu.closest('.dropdown-wrapper');
+        const toggleButton = wrapper ? wrapper.querySelector('.dropdown-toggle') : null;
+        if (!toggleButton) return;
+
+        const buttonRect = toggleButton.getBoundingClientRect();
+        const viewportPadding = 16;
+        const menuWidth = Math.min(260, window.innerWidth - viewportPadding * 2);
+        const availableRight = window.innerWidth - viewportPadding;
+        const left = Math.min(
+            Math.max(buttonRect.left, viewportPadding),
+            availableRight - menuWidth
+        );
+
+        menu.style.position = 'fixed';
+        menu.style.top = `${buttonRect.bottom + 8}px`;
+        menu.style.left = `${left}px`;
+        menu.style.right = 'auto';
+        menu.style.width = `${menuWidth}px`;
+        menu.style.maxWidth = `${window.innerWidth - viewportPadding * 2}px`;
+    }
+
     function toggleDropdown(id) {
         const el = document.getElementById(id);
-        if (el) {
-            el.classList.toggle('show');
-            document.querySelectorAll('.dropdown-menu').forEach(d => {
-                if (d.id !== id) d.classList.remove('show');
-            });
+        if (!el) return;
+
+        const shouldShow = !el.classList.contains('show');
+        document.querySelectorAll('.dropdown-menu').forEach(d => d.classList.remove('show'));
+
+        if (shouldShow) {
+            positionFloatingDropdown(el);
+            el.classList.add('show');
         }
     }
+
+    window.addEventListener('resize', () => {
+        document.querySelectorAll('.dropdown-menu.show.dropdown-menu-floating').forEach(positionFloatingDropdown);
+    });
+
+    window.addEventListener('scroll', () => {
+        document.querySelectorAll('.dropdown-menu.show.dropdown-menu-floating').forEach(positionFloatingDropdown);
+    }, true);
 
     // Close dropdowns
     document.addEventListener('click', (e) => {


### PR DESCRIPTION
### Motivation
- The status filter dropdown currently participates in the document flow and expands the toolbar height when opened, which breaks the toolbar layout. 
- The goal is to make the dropdown hover above the toolbar so opening it doesn't push other content.

### Description
- Add a new CSS utility class `dropdown-menu-floating` and apply it to `#statusFilterDropdown` in `app/templates/admin/index.html` so the status menu can be rendered as an overlay. 
- Introduce `positionFloatingDropdown(menu)` to compute and set `top/left/width` and wire it into `toggleDropdown(id)`, plus listeners on `resize` and `scroll`, so the floating menu follows the filter button. 
- Add fixed-position styling for `.dropdown-menu-floating` in `app/static/css/style.css` with a higher `z-index` and viewport width constraints to keep the menu on-screen.

### Testing
- Run `python -m compileall app` to verify Python modules compile, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bfdb9fbb488320a3e2affa7239fcae)