### PR TITLE
Adjust z-index so team toolbar dropdown overlays team table

### DIFF
--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -121,13 +121,24 @@
     }
 
     .team-list-toolbar-section {
-        z-index: 40;
+        position: relative;
+        z-index: 60;
         overflow: visible;
+    }
+
+    .team-list-toolbar-section:focus-within,
+    .team-list-toolbar-section:hover {
+        z-index: 80;
+    }
+
+    .team-toolbar {
+        position: relative;
+        z-index: 2;
     }
 
     .team-list-table-container {
         position: relative;
-        z-index: 1;
+        z-index: 0;
     }
 
     .team-toolbar .dropdown-menu-floating {


### PR DESCRIPTION
### Motivation
- The status filter dropdown in the Team info page was being covered by the team list/table, so the toolbar stacking needed to be raised to ensure the dropdown is visible during interaction.

### Description
- Modified `app/templates/admin/index.html` CSS to set `.team-list-toolbar-section` to `position: relative` and `z-index: 60` and keep `overflow: visible` so dropdowns are not clipped.
- Added `:hover` and `:focus-within` rules to `.team-list-toolbar-section` to temporarily raise the stacking to `z-index: 80` while interacting with the toolbar.
- Added `position: relative` and `z-index: 2` to `.team-toolbar` and lowered `.team-list-table-container` to `z-index: 0` so the toolbar and its floating `.dropdown-menu-floating` can overlay the table as intended.

### Testing
- Ran `python -m py_compile app/main.py app/routes/admin.py` and it succeeded with no syntax errors.
- Verified the CSS block in `app/templates/admin/index.html` was updated and contains the new stacking rules.
- UI screenshot could not be produced because the browser screenshot tool is unavailable in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bff0cf272c83209dfd25db31002891)