### PR TITLE
Fix floating dropdown positioning in admin tables

### DIFF
--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -278,8 +278,20 @@ function syncResponsiveSidebarMount() {
     }
 }
 
+function mountFloatingDropdownsToBody() {
+    document.querySelectorAll('.dropdown-menu-floating').forEach((menu) => {
+        const wrapper = menu.closest('.dropdown-wrapper');
+        if (!wrapper || menu.parentElement === document.body) return;
+
+        menu._dropdownWrapper = wrapper;
+        document.body.appendChild(menu);
+    });
+}
+
 // 页面加载完成后执行
 document.addEventListener('DOMContentLoaded', function () {
+    mountFloatingDropdownsToBody();
+
     // 检查认证状态
     checkAuthStatus();
 

--- a/app/templates/admin/codes/index.html
+++ b/app/templates/admin/codes/index.html
@@ -74,7 +74,7 @@
                     <button class="btn btn-secondary btn-sm dropdown-toggle" onclick="toggleDropdown('columnToggleDropdown')">
                         <i data-lucide="columns" style="width: 16px; height: 16px;"></i> 列设置
                     </button>
-                    <div id="columnToggleDropdown" class="dropdown-menu">
+                    <div id="columnToggleDropdown" class="dropdown-menu dropdown-menu-floating">
                         <!-- Column checkboxes will be generated here -->
                     </div>
                 </div>
@@ -561,7 +561,49 @@
 <script>
     let scannedInvalidCodes = [];
 
+    function prepareFloatingDropdowns() {
+        document.querySelectorAll('.dropdown-menu-floating').forEach((menu) => {
+            const wrapper = menu.closest('.dropdown-wrapper');
+            if (!wrapper || menu.parentElement === document.body) return;
+
+            menu._dropdownWrapper = wrapper;
+            document.body.appendChild(menu);
+        });
+    }
+
+    function positionFloatingDropdown(menu) {
+        if (!menu || !menu.classList.contains('dropdown-menu-floating')) return;
+
+        const wrapper = menu._dropdownWrapper || menu.closest('.dropdown-wrapper');
+        if (!wrapper) return;
+
+        const wrapperRect = wrapper.getBoundingClientRect();
+        const viewportPadding = 16;
+        const menuWidth = Math.min(260, window.innerWidth - viewportPadding * 2);
+
+        let left = wrapperRect.left;
+        if (left + menuWidth + viewportPadding > window.innerWidth) {
+            left = window.innerWidth - menuWidth - viewportPadding;
+        }
+        left = Math.max(viewportPadding, left);
+
+        menu.style.position = 'fixed';
+        menu.style.top = `${wrapperRect.bottom + 8}px`;
+        menu.style.left = `${left}px`;
+        menu.style.right = 'auto';
+        menu.style.width = `${menuWidth}px`;
+        menu.style.maxWidth = 'calc(100vw - 2rem)';
+        menu.style.zIndex = '9999';
+    }
+
+    function closeAllDropdowns() {
+        document.querySelectorAll('.dropdown-menu.show').forEach((menu) => {
+            menu.classList.remove('show');
+        });
+    }
+
     document.addEventListener('DOMContentLoaded', () => {
+        prepareFloatingDropdowns();
         // Init Column Toggler
         initColumnToggler('.data-table', 'codes_list_columns');
     });
@@ -621,18 +663,29 @@
 
     function toggleDropdown(id) {
         const el = document.getElementById(id);
-        if (el) {
-            el.classList.toggle('show');
-            document.querySelectorAll('.dropdown-menu').forEach(d => {
-                if (d.id !== id) d.classList.remove('show');
-            });
+        if (!el) return;
+
+        const shouldShow = !el.classList.contains('show');
+        closeAllDropdowns();
+
+        if (shouldShow) {
+            positionFloatingDropdown(el);
+            el.classList.add('show');
         }
     }
+
+    window.addEventListener('resize', () => {
+        document.querySelectorAll('.dropdown-menu.show.dropdown-menu-floating').forEach(positionFloatingDropdown);
+    });
+
+    window.addEventListener('scroll', () => {
+        document.querySelectorAll('.dropdown-menu.show.dropdown-menu-floating').forEach(positionFloatingDropdown);
+    }, true);
 
     // Close dropdowns
     document.addEventListener('click', (e) => {
         if (!e.target.closest('.dropdown-wrapper') && !e.target.closest('.dropdown-toggle')) {
-            document.querySelectorAll('.dropdown-menu').forEach(d => d.classList.remove('show'));
+            closeAllDropdowns();
         }
     });
 

--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -1051,7 +1051,7 @@
     function positionFloatingDropdown(menu) {
         if (!menu || !menu.classList.contains('dropdown-menu-floating')) return;
 
-        const wrapper = menu.closest('.dropdown-wrapper');
+        const wrapper = menu._dropdownWrapper || menu.closest('.dropdown-wrapper');
         if (!wrapper) return;
 
         const wrapperRect = wrapper.getBoundingClientRect();

--- a/app/templates/admin/records/index.html
+++ b/app/templates/admin/records/index.html
@@ -93,7 +93,7 @@
                 <button class="btn btn-secondary dropdown-toggle" onclick="toggleDropdown('columnToggleDropdown')">
                     <i data-lucide="columns" style="width: 16px; height: 16px;"></i> 列设置
                 </button>
-                <div id="columnToggleDropdown" class="dropdown-menu">
+                <div id="columnToggleDropdown" class="dropdown-menu dropdown-menu-floating">
                     <!-- Column checkboxes will be generated here -->
                 </div>
             </div>
@@ -311,7 +311,49 @@
         }
     }
 
+    function prepareFloatingDropdowns() {
+        document.querySelectorAll('.dropdown-menu-floating').forEach((menu) => {
+            const wrapper = menu.closest('.dropdown-wrapper');
+            if (!wrapper || menu.parentElement === document.body) return;
+
+            menu._dropdownWrapper = wrapper;
+            document.body.appendChild(menu);
+        });
+    }
+
+    function positionFloatingDropdown(menu) {
+        if (!menu || !menu.classList.contains('dropdown-menu-floating')) return;
+
+        const wrapper = menu._dropdownWrapper || menu.closest('.dropdown-wrapper');
+        if (!wrapper) return;
+
+        const wrapperRect = wrapper.getBoundingClientRect();
+        const viewportPadding = 16;
+        const menuWidth = Math.min(260, window.innerWidth - viewportPadding * 2);
+
+        let left = wrapperRect.left;
+        if (left + menuWidth + viewportPadding > window.innerWidth) {
+            left = window.innerWidth - menuWidth - viewportPadding;
+        }
+        left = Math.max(viewportPadding, left);
+
+        menu.style.position = 'fixed';
+        menu.style.top = `${wrapperRect.bottom + 8}px`;
+        menu.style.left = `${left}px`;
+        menu.style.right = 'auto';
+        menu.style.width = `${menuWidth}px`;
+        menu.style.maxWidth = 'calc(100vw - 2rem)';
+        menu.style.zIndex = '9999';
+    }
+
+    function closeAllDropdowns() {
+        document.querySelectorAll('.dropdown-menu.show').forEach((menu) => {
+            menu.classList.remove('show');
+        });
+    }
+
     document.addEventListener('DOMContentLoaded', () => {
+        prepareFloatingDropdowns();
         // Init Column Toggler
         initColumnToggler('.data-table', 'records_list_columns');
     });
@@ -371,18 +413,29 @@
 
     function toggleDropdown(id) {
         const el = document.getElementById(id);
-        if (el) {
-            el.classList.toggle('show');
-            document.querySelectorAll('.dropdown-menu').forEach(d => {
-                if (d.id !== id) d.classList.remove('show');
-            });
+        if (!el) return;
+
+        const shouldShow = !el.classList.contains('show');
+        closeAllDropdowns();
+
+        if (shouldShow) {
+            positionFloatingDropdown(el);
+            el.classList.add('show');
         }
     }
+
+    window.addEventListener('resize', () => {
+        document.querySelectorAll('.dropdown-menu.show.dropdown-menu-floating').forEach(positionFloatingDropdown);
+    });
+
+    window.addEventListener('scroll', () => {
+        document.querySelectorAll('.dropdown-menu.show.dropdown-menu-floating').forEach(positionFloatingDropdown);
+    }, true);
 
     // Close dropdowns
     document.addEventListener('click', (e) => {
         if (!e.target.closest('.dropdown-wrapper') && !e.target.closest('.dropdown-toggle')) {
-            document.querySelectorAll('.dropdown-menu').forEach(d => d.classList.remove('show'));
+            closeAllDropdowns();
         }
     });
 


### PR DESCRIPTION
### Motivation

- Floating dropdowns positioned with `position: fixed` were still constrained by ancestor `transform`/stacking contexts and therefore misaligned relative to the viewport. 
- The long-term fix is to move floating dropdown nodes into `document.body` so `position: fixed` is truly viewport‑relative and not affected by transformed ancestors.

### Description

- Add `mountFloatingDropdownsToBody()` in `app/static/js/main.js` and call it at the top of the global `DOMContentLoaded` handler to move `.dropdown-menu-floating` menus to `document.body` and stash their original wrapper in `menu._dropdownWrapper`.
- Use the saved wrapper reference when computing coordinates by updating `positionFloatingDropdown` to prefer `menu._dropdownWrapper || menu.closest('.dropdown-wrapper')` in `app/templates/admin/index.html` and duplicated positioning logic in the `records` and `codes` pages.
- Mark the column-toggle dropdowns as floating by adding the `dropdown-menu-floating` class to the column toggles in `app/templates/admin/records/index.html` and `app/templates/admin/codes/index.html` and add helper functions (`prepareFloatingDropdowns`, `positionFloatingDropdown`, `closeAllDropdowns`) and event handlers (resize/scroll) to those pages so they behave consistently.
- Update `toggleDropdown` to close other dropdowns first and to call `positionFloatingDropdown` before showing, ensuring correct fixed placement after the menu is mounted to `body`.

### Testing

- Ran `git diff --check` to validate diff hygiene and it completed without errors.
- Created a commit with message `Fix floating dropdown positioning` successfully (commit created). 
- No automated browser/visual tests were available in the environment, so layout verification remains manual in a browser (not executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bffa8ce38c83208d56bc247c03f7af)