### PR TITLE
Add Team JSON export actions and auth file reuse.

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -2,12 +2,14 @@
 管理员路由
 处理管理员面板的所有页面和操作
 """
+import json
 import logging
 import re
+import zipfile
+from io import BytesIO
 from typing import Optional, List, Dict, Literal
 from fastapi import APIRouter, Depends, HTTPException, Query, status, Request
-from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
-import json
+from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse, Response
 from sqlalchemy import select, func, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from pydantic import BaseModel, Field
@@ -173,14 +175,13 @@ async def admin_dashboard(
         
         # 获取统计信息 (使用专用统计方法优化)
         team_stats = await team_service.get_stats(db, pool_type="normal")
-        code_stats = await redemption_service.get_stats(db, pool_type="normal")
 
         # 计算统计数据
         stats = {
             "total_teams": team_stats["total"],
             "available_teams": team_stats["available"],
-            "total_codes": code_stats["total"],
-            "used_codes": code_stats["used"]
+            "banned_teams": team_stats["banned"],
+            "expired_teams": team_stats["expired"],
         }
 
         return templates.TemplateResponse(
@@ -915,6 +916,135 @@ async def enable_team_device_auth(
                 "success": False,
                 "error": "操作失败，请稍后重试"
             }
+        )
+
+
+@router.get("/teams/{team_id}/export-json")
+async def export_team_json(
+    team_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: dict = Depends(require_admin)
+):
+    """导出单个 Team 的 JSON 认证文件。"""
+    try:
+        logger.info("管理员导出 Team %s 的 JSON 认证文件", team_id)
+        result = await cliproxyapi_service.get_team_auth_file_data(team_id, db)
+        if not result.get("success"):
+            return JSONResponse(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                content=result
+            )
+
+        payload_bytes = json.dumps(
+            result.get("payload") or {},
+            ensure_ascii=False,
+            indent=2,
+        ).encode("utf-8")
+        filename = str(result.get("filename") or f"team-{team_id}.json")
+        quoted_filename = json.dumps(filename, ensure_ascii=False)
+        headers = {
+            "Content-Disposition": f"attachment; filename*=UTF-8''{filename}; filename={quoted_filename}"
+        }
+        return Response(content=payload_bytes, media_type="application/json; charset=utf-8", headers=headers)
+    except Exception as e:
+        logger.error("导出 Team %s 的 JSON 认证文件失败: %s", team_id, e)
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content={"success": False, "error": str(e)}
+        )
+
+
+@router.post("/teams/batch-export-json")
+async def batch_export_team_json(
+    action_data: BulkActionRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: dict = Depends(require_admin)
+):
+    """批量导出 Team 的 JSON 认证文件并打包为 zip。"""
+    try:
+        team_ids = [team_id for team_id in action_data.ids if isinstance(team_id, int)]
+        if not team_ids:
+            return JSONResponse(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                content={"success": False, "error": "请选择要导出的 Team"}
+            )
+
+        logger.info("管理员批量导出 %s 个 Team 的 JSON 认证文件", len(team_ids))
+
+        zip_buffer = BytesIO()
+        exported_count = 0
+        failed_count = 0
+        warning_count = 0
+        results = []
+
+        with zipfile.ZipFile(zip_buffer, mode="w", compression=zipfile.ZIP_DEFLATED) as zip_file:
+            for team_id in team_ids:
+                result = await cliproxyapi_service.get_team_auth_file_data(team_id, db)
+                if not result.get("success"):
+                    failed_count += 1
+                    results.append({
+                        "team_id": team_id,
+                        "email": result.get("email"),
+                        "filename": None,
+                        "warning": None,
+                        "warnings": [],
+                        "error": result.get("error"),
+                    })
+                    continue
+
+                filename = str(result.get("filename") or f"team-{team_id}.json")
+                payload_text = json.dumps(result.get("payload") or {}, ensure_ascii=False, indent=2)
+                zip_file.writestr(filename, payload_text)
+
+                exported_count += 1
+                if result.get("warning"):
+                    warning_count += 1
+                results.append({
+                    "team_id": team_id,
+                    "email": result.get("email"),
+                    "filename": filename,
+                    "warning": result.get("warning"),
+                    "warnings": result.get("warnings") or [],
+                    "error": None,
+                })
+
+            if failed_count > 0:
+                summary_payload = {
+                    "success": failed_count == 0,
+                    "message": f"批量导出完成：成功 {exported_count}，失败 {failed_count}",
+                    "exported_count": exported_count,
+                    "failed_count": failed_count,
+                    "warning_count": warning_count,
+                    "results": results,
+                }
+                zip_file.writestr("export-summary.json", json.dumps(summary_payload, ensure_ascii=False, indent=2))
+
+        if exported_count == 0:
+            return JSONResponse(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                content={
+                    "success": False,
+                    "error": "选中的 Team 都无法导出 JSON",
+                    "failed_count": failed_count,
+                    "results": results,
+                }
+            )
+
+        zip_buffer.seek(0)
+        archive_name = f"teams-json-export-{get_now().strftime('%Y%m%d%H%M%S')}.zip"
+        quoted_archive_name = json.dumps(archive_name, ensure_ascii=False)
+        headers = {
+            "Content-Disposition": f"attachment; filename*=UTF-8''{archive_name}; filename={quoted_archive_name}",
+            "X-Exported-Count": str(exported_count),
+            "X-Failed-Count": str(failed_count),
+            "X-Warning-Count": str(warning_count),
+        }
+        return Response(content=zip_buffer.getvalue(), media_type="application/zip", headers=headers)
+    except Exception as e:
+        logger.error("批量导出 Team JSON 失败: %s", e)
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content={"success": False, "error": str(e)}
         )
 
 

--- a/app/services/cliproxyapi.py
+++ b/app/services/cliproxyapi.py
@@ -14,6 +14,7 @@ from app.config import settings
 from app.models import Team
 from app.services.encryption import encryption_service
 from app.services.settings import settings_service
+from app.utils.jwt_parser import JWTParser
 from app.utils.time_utils import get_now
 
 logger = logging.getLogger(__name__)
@@ -29,6 +30,10 @@ class CliproxyapiConfig:
 class CliproxyapiService:
     MANAGEMENT_PREFIX = "/v0/management"
     DEFAULT_TIMEOUT = 20.0
+    PLACEHOLDER_ACCOUNT_IDS = {"default", "personal", "none", "null", "me", "self"}
+
+    def __init__(self):
+        self.jwt_parser = JWTParser()
 
     @staticmethod
     def normalize_base_url(base_url: Optional[str]) -> str:
@@ -94,6 +99,23 @@ class CliproxyapiService:
         )
 
     @staticmethod
+    def _normalize_account_id(value: Optional[str]) -> str:
+        normalized = str(value or "").strip()
+        if not normalized:
+            return ""
+        if normalized.lower() in CliproxyapiService.PLACEHOLDER_ACCOUNT_IDS:
+            return ""
+        return normalized
+
+    def _resolve_client_id(self, team: Team, access_token: str) -> str:
+        client_id = str(team.client_id or "").strip()
+        if client_id:
+            return client_id
+
+        extracted_client_id = self.jwt_parser.extract_client_id(access_token)
+        return str(extracted_client_id or "").strip()
+
+    @staticmethod
     def _build_warning_message(missing_fields: list[str]) -> str:
         if not missing_fields:
             return ""
@@ -101,6 +123,7 @@ class CliproxyapiService:
         field_labels = {
             "id_token": "id_token",
             "refresh_token": "refresh_token",
+            "client_id": "client_id",
         }
         labels = [field_labels.get(field, field) for field in missing_fields]
         joined = "、".join(labels)
@@ -112,12 +135,14 @@ class CliproxyapiService:
         access_token: str,
         id_token: str,
         refresh_token: str,
+        client_id: str,
     ) -> Dict[str, Any]:
         # last_refresh 取同步时间而不是推送时间，避免重复推送因时间戳变化而失去幂等。
         last_refresh_time = team.last_sync or team.created_at or get_now()
         return {
             "access_token": access_token,
-            "account_id": team.account_id or "",
+            "account_id": self._normalize_account_id(team.account_id),
+            "client_id": client_id,
             "email": team.email or "",
             "expired": self._to_local_iso(team.expires_at),
             "id_token": id_token,
@@ -131,6 +156,59 @@ class CliproxyapiService:
         if team.expires_at:
             return f"{safe_email}__exp-{team.expires_at.strftime('%Y%m%d%H%M%S')}.json"
         return f"{safe_email}__team-{team.id}.json"
+
+    async def get_team_auth_file_data(self, team_id: int, db_session: AsyncSession) -> Dict[str, Any]:
+        result = await db_session.execute(select(Team).where(Team.id == team_id))
+        team = result.scalar_one_or_none()
+        if not team:
+            return {"success": False, "error": "Team 不存在"}
+
+        email = str(team.email or "").strip()
+        if not email:
+            return {"success": False, "error": "Team 缺少邮箱，无法生成认证文件", "email": ""}
+
+        try:
+            access_token = encryption_service.decrypt_token(team.access_token_encrypted)
+        except Exception as exc:
+            logger.error("解密 Team %s access_token 失败: %s", team_id, exc)
+            access_token = ""
+
+        if not access_token:
+            return {"success": False, "error": "Team 缺少 Access Token，无法导出认证文件", "email": email}
+
+        refresh_token = ""
+        try:
+            if team.refresh_token_encrypted:
+                refresh_token = encryption_service.decrypt_token(team.refresh_token_encrypted)
+        except Exception as exc:
+            logger.warning("解密 Team %s refresh_token 失败，将按空值导出: %s", team_id, exc)
+
+        id_token = ""
+        try:
+            if team.id_token_encrypted:
+                id_token = encryption_service.decrypt_token(team.id_token_encrypted)
+        except Exception as exc:
+            logger.warning("解密 Team %s id_token 失败，将按空值导出: %s", team_id, exc)
+
+        client_id = self._resolve_client_id(team, access_token)
+
+        missing_fields = []
+        if not id_token:
+            missing_fields.append("id_token")
+        if not refresh_token:
+            missing_fields.append("refresh_token")
+        if not client_id:
+            missing_fields.append("client_id")
+
+        return {
+            "success": True,
+            "team_id": team_id,
+            "email": email,
+            "filename": self._build_filename(team),
+            "payload": self._build_payload(team, access_token, id_token, refresh_token, client_id),
+            "warning": self._build_warning_message(missing_fields) or None,
+            "warnings": missing_fields,
+        }
 
     def _normalize_downloaded_payload(self, content: str) -> Optional[Dict[str, Any]]:
         try:
@@ -206,47 +284,15 @@ class CliproxyapiService:
         if not self.is_valid_base_url(config.base_url):
             return {"success": False, "error": "CliproxyAPI 地址格式错误，仅支持 http/https"}
 
-        result = await db_session.execute(select(Team).where(Team.id == team_id))
-        team = result.scalar_one_or_none()
-        if not team:
-            return {"success": False, "error": "Team 不存在"}
+        team_auth_data = await self.get_team_auth_file_data(team_id, db_session)
+        if not team_auth_data.get("success"):
+            return team_auth_data
 
-        email = str(team.email or "").strip()
-        if not email:
-            return {"success": False, "error": "Team 缺少邮箱，无法生成认证文件", "email": ""}
-
-        try:
-            access_token = encryption_service.decrypt_token(team.access_token_encrypted)
-        except Exception as exc:
-            logger.error("解密 Team %s access_token 失败: %s", team_id, exc)
-            access_token = ""
-
-        if not access_token:
-            return {"success": False, "error": "Team 缺少 Access Token，无法推送", "email": email}
-
-        refresh_token = ""
-        try:
-            if team.refresh_token_encrypted:
-                refresh_token = encryption_service.decrypt_token(team.refresh_token_encrypted)
-        except Exception as exc:
-            logger.warning("解密 Team %s refresh_token 失败，将按空值推送: %s", team_id, exc)
-
-        id_token = ""
-        try:
-            if team.id_token_encrypted:
-                id_token = encryption_service.decrypt_token(team.id_token_encrypted)
-        except Exception as exc:
-            logger.warning("解密 Team %s id_token 失败，将按空值推送: %s", team_id, exc)
-
-        missing_fields = []
-        if not id_token:
-            missing_fields.append("id_token")
-        if not refresh_token:
-            missing_fields.append("refresh_token")
-        warning_message = self._build_warning_message(missing_fields)
-
-        filename = self._build_filename(team)
-        payload = self._build_payload(team, access_token, id_token, refresh_token)
+        email = team_auth_data.get("email") or ""
+        filename = team_auth_data.get("filename") or ""
+        payload = team_auth_data.get("payload") or {}
+        missing_fields = team_auth_data.get("warnings") or []
+        warning_message = team_auth_data.get("warning") or ""
         canonical_payload = self._canonical_json(payload)
         management_base_url = f"{config.base_url}{self.MANAGEMENT_PREFIX}"
 

--- a/app/services/team.py
+++ b/app/services/team.py
@@ -2977,7 +2977,7 @@ class TeamService:
                 total_stmt = total_stmt.where(Team.pool_type == pool_type)
             total_result = await db_session.execute(total_stmt)
             total = total_result.scalar() or 0
-            
+
             # 可用 Team 数 (状态为 active 且未满)
             available_stmt = select(func.count(Team.id)).where(
                 Team.status == "active",
@@ -2987,14 +2987,28 @@ class TeamService:
                 available_stmt = available_stmt.where(Team.pool_type == pool_type)
             available_result = await db_session.execute(available_stmt)
             available = available_result.scalar() or 0
-            
+
+            banned_stmt = select(func.count(Team.id)).where(Team.status == "banned")
+            if pool_type:
+                banned_stmt = banned_stmt.where(Team.pool_type == pool_type)
+            banned_result = await db_session.execute(banned_stmt)
+            banned = banned_result.scalar() or 0
+
+            expired_stmt = select(func.count(Team.id)).where(Team.status == "expired")
+            if pool_type:
+                expired_stmt = expired_stmt.where(Team.pool_type == pool_type)
+            expired_result = await db_session.execute(expired_stmt)
+            expired = expired_result.scalar() or 0
+
             return {
                 "total": total,
-                "available": available
+                "available": available,
+                "banned": banned,
+                "expired": expired,
             }
         except Exception as e:
             logger.error(f"获取 Team 统计信息失败: {e}")
-            return {"total": 0, "available": 0}
+            return {"total": 0, "available": 0, "banned": 0, "expired": 0}
 
 
 # 创建全局 Team 服务实例

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -582,13 +582,6 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     }
 
-    const btnExportOAuthJson = document.getElementById('btnExportOAuthJson');
-    if (btnExportOAuthJson) {
-        btnExportOAuthJson.addEventListener('click', () => {
-            exportOAuthJsonTemplateFile();
-        });
-    }
-
     const switchToManualFill = document.getElementById('switchToManualFill');
     if (switchToManualFill) {
         switchToManualFill.addEventListener('click', () => setSingleImportMode('manual'));
@@ -933,31 +926,6 @@ function buildOAuthJsonTemplate(parsedData) {
         refresh_token: refreshToken,
         type: raw.type || parsedData.type || 'codex'
     };
-}
-
-function downloadJsonFile(payload, filename) {
-    const text = JSON.stringify(payload, null, 2);
-    const blob = new Blob([text], { type: 'application/json;charset=utf-8' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = filename;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
-}
-
-async function exportOAuthJsonTemplateFile() {
-    try {
-        const data = oauthParsedCache || await parseOAuthCallbackData();
-        const payload = buildOAuthJsonTemplate(data);
-        const filename = `team-oauth-${Date.now()}.json`;
-        downloadJsonFile(payload, filename);
-        showToast('JSON 文件已导出', 'success');
-    } catch (error) {
-        showToast(getFriendlyAdminErrorMessage(error.message || '导出 JSON 失败', 0, 'oauth'), 'error');
-    }
 }
 
 async function parseOAuthCallbackAndFill() {

--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -319,17 +319,17 @@
     </div>
     {% else %}
     <div class="stat-card stat-info">
-        <div class="stat-icon"><i data-lucide="ticket"></i></div>
+        <div class="stat-icon"><i data-lucide="alert-triangle"></i></div>
         <div class="stat-info-group">
-            <div class="stat-value">{{ stats.total_codes }}</div>
-            <div class="stat-label">兑换码总数</div>
+            <div class="stat-value">{{ stats.banned_teams }}</div>
+            <div class="stat-label">已封禁 Team</div>
         </div>
     </div>
     <div class="stat-card stat-warning">
-        <div class="stat-icon"><i data-lucide="clipboard-list"></i></div>
+        <div class="stat-icon"><i data-lucide="clock-3"></i></div>
         <div class="stat-info-group">
-            <div class="stat-value">{{ stats.used_codes }}</div>
-            <div class="stat-label">已使用兑换码</div>
+            <div class="stat-value">{{ stats.expired_teams }}</div>
+            <div class="stat-label">已过期 Team</div>
         </div>
     </div>
     {% endif %}
@@ -359,6 +359,9 @@
                 </button>
                 <button type="button" id="btnBatchPushCliproxyapi" class="btn btn-primary btn-sm">
                     <i data-lucide="send" style="width: 14px; height: 14px;"></i> 批量推送
+                </button>
+                <button type="button" id="btnBatchExportJson" class="btn btn-secondary btn-sm">
+                    <i data-lucide="download" style="width: 14px; height: 14px;"></i> 批量导出 JSON
                 </button>
                 <button type="button" id="btnBatchDelete" class="btn btn-danger btn-sm">
                     <i data-lucide="trash-2" style="width: 14px; height: 14px;"></i> 批量删除
@@ -549,6 +552,11 @@
                             data-id="{{ team.id }}" data-email="{{ team.email }}" title="推送到 CliproxyAPI" aria-label="推送到 CliproxyAPI">
                             <i data-lucide="send" style="width: 16px; height: 16px;"></i>
                             <span class="btn-icon-fallback" aria-hidden="true">推</span>
+                        </button>
+                        <button class="btn btn-sm btn-icon btn-minimal btn-secondary btn-export-team-json"
+                            data-id="{{ team.id }}" data-email="{{ team.email }}" title="导出 JSON" aria-label="导出 JSON">
+                            <i data-lucide="download" style="width: 16px; height: 16px;"></i>
+                            <span class="btn-icon-fallback" aria-hidden="true">导</span>
                         </button>
                         <button type="button" class="btn btn-sm btn-icon btn-minimal btn-danger btn-delete-team"
                             data-id="{{ team.id }}" data-email="{{ team.email }}" title="删除" aria-label="删除"
@@ -825,6 +833,14 @@
             });
         });
 
+        document.querySelectorAll('.btn-export-team-json').forEach(btn => {
+            btn.addEventListener('click', () => {
+                const id = btn.getAttribute('data-id');
+                const email = btn.getAttribute('data-email');
+                exportTeamJson(id, email);
+            });
+        });
+
         // 绑定复选框事件（避免仅依赖内联 onchange）
         document.getElementById('selectAll')?.addEventListener('change', (e) => {
             toggleSelectAll(Boolean(e.target && e.target.checked));
@@ -837,6 +853,7 @@
         document.getElementById('btnBatchRefresh')?.addEventListener('click', handleBatchRefresh);
         document.getElementById('btnBatchEnableDeviceAuth')?.addEventListener('click', handleBatchEnableDeviceAuth);
         document.getElementById('btnBatchPushCliproxyapi')?.addEventListener('click', handleBatchPushCliproxyapi);
+        document.getElementById('btnBatchExportJson')?.addEventListener('click', handleBatchExportJson);
         document.getElementById('btnBatchDelete')?.addEventListener('click', handleBatchDelete);
         document.getElementById('btnBatchTransferPool')?.addEventListener('click', handleBatchTransferPool);
     });
@@ -902,6 +919,66 @@
             }
         } catch (error) {
             showToast('网络错误', 'error');
+        }
+    }
+
+    function triggerDownloadFromBlob(blob, filename) {
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+    }
+
+    function parseDownloadFilename(contentDisposition, fallbackName) {
+        if (!contentDisposition) {
+            return fallbackName;
+        }
+
+        const utf8Match = contentDisposition.match(/filename\*=UTF-8''([^;]+)/i);
+        if (utf8Match && utf8Match[1]) {
+            try {
+                return decodeURIComponent(utf8Match[1]);
+            } catch (_) {
+                return utf8Match[1];
+            }
+        }
+
+        const plainMatch = contentDisposition.match(/filename=(?:"([^"]+)"|([^;]+))/i);
+        if (plainMatch) {
+            return (plainMatch[1] || plainMatch[2] || fallbackName).trim();
+        }
+
+        return fallbackName;
+    }
+
+    async function exportTeamJson(teamId, email = '') {
+        const targetLabel = email ? `"${email}"` : `ID=${teamId}`;
+        if (!confirm(`确定要导出 Team ${targetLabel} 的 JSON 吗？`)) {
+            return;
+        }
+
+        try {
+            showToast('正在导出 JSON...', 'info');
+            const response = await fetch(`/admin/teams/${teamId}/export-json`);
+            if (!response.ok) {
+                const errorData = await response.json().catch(() => ({}));
+                throw new Error(errorData.error || '导出 JSON 失败');
+            }
+
+            const blob = await response.blob();
+            const filename = parseDownloadFilename(
+                response.headers.get('Content-Disposition'),
+                `team-${teamId}.json`
+            );
+            triggerDownloadFromBlob(blob, filename);
+            showToast('JSON 文件已导出', 'success');
+        } catch (error) {
+            console.error(error);
+            showToast(error.message || '导出 JSON 失败', 'error');
         }
     }
 
@@ -1355,7 +1432,7 @@
     }
 
     function setBatchActionButtonsDisabled(disabled) {
-        ['btnBatchRefresh', 'btnBatchEnableDeviceAuth', 'btnBatchPushCliproxyapi', 'btnBatchDelete', 'btnBatchTransferPool'].forEach(id => {
+        ['btnBatchRefresh', 'btnBatchEnableDeviceAuth', 'btnBatchPushCliproxyapi', 'btnBatchExportJson', 'btnBatchDelete', 'btnBatchTransferPool'].forEach(id => {
             const button = document.getElementById(id);
             if (button) button.disabled = disabled;
         });
@@ -1583,6 +1660,63 @@
                 };
             }
         });
+    }
+
+    async function handleBatchExportJson() {
+        const selectedIds = getSelectedTeamIds();
+
+        if (selectedIds.length === 0) {
+            showToast('请选择要导出的 Team', 'warning');
+            return;
+        }
+
+        if (!confirm(`确定要批量导出选中的 ${selectedIds.length} 个 Team JSON 吗？`)) {
+            return;
+        }
+
+        try {
+            showToast(`正在批量导出 ${selectedIds.length} 个 Team 的 JSON...`, 'info');
+            setBatchActionButtonsDisabled(true);
+
+            const response = await fetch('/admin/teams/batch-export-json', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ ids: selectedIds })
+            });
+
+            if (!response.ok) {
+                const errorData = await response.json().catch(() => ({}));
+                throw new Error(errorData.error || '批量导出 JSON 失败');
+            }
+
+            const blob = await response.blob();
+            const filename = parseDownloadFilename(
+                response.headers.get('Content-Disposition'),
+                `teams-json-export-${Date.now()}.zip`
+            );
+            const exportedCount = parseInt(response.headers.get('X-Exported-Count') || `${selectedIds.length}`, 10) || selectedIds.length;
+            const failedCount = parseInt(response.headers.get('X-Failed-Count') || '0', 10) || 0;
+            const warningCount = parseInt(response.headers.get('X-Warning-Count') || '0', 10) || 0;
+
+            triggerDownloadFromBlob(blob, filename);
+
+            let message = `批量导出完成：成功 ${exportedCount}`;
+            if (failedCount > 0) {
+                message += `，失败 ${failedCount}`;
+            }
+            if (warningCount > 0) {
+                message += `，其中 ${warningCount} 个 Team 缺少部分凭证字段`;
+            }
+
+            showToast(message, failedCount > 0 || warningCount > 0 ? 'warning' : 'success');
+        } catch (error) {
+            console.error(error);
+            showToast(error.message || '批量导出 JSON 失败', 'error');
+        } finally {
+            setBatchActionButtonsDisabled(false);
+        }
     }
 
     function handleBatchTransferPool() {

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -159,7 +159,6 @@
 
                             <div class="oauth-quick-btn-row">
                                 <button type="button" id="btnParseOAuthCallback" class="btn btn-primary">解析并自动填充</button>
-                                <button type="button" id="btnExportOAuthJson" class="btn btn-primary">导出 JSON</button>
                                 <button type="submit" id="btnQuickImportTeam" class="btn btn-primary">导入 Team</button>
                             </div>
 


### PR DESCRIPTION
This moves JSON export from the import modal to the Team list, supports bulk ZIP exports, and reuses the Cliproxy auth payload builder so exports and pushes stay consistent.