### PR TITLE
Fix welfare redemption guards and mobile admin tables

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -241,16 +241,17 @@ async def welfare_dashboard(
         welfare_usage = await redemption_service.get_virtual_welfare_code_usage(db)
         welfare_code = str(welfare_usage.get("welfare_code") or "")
         welfare_used = int(welfare_usage.get("used_count") or 0)
-        effective_limit = max(int(welfare_usage.get("remaining_count") or 0), 0)
+        configured_limit = max(int(welfare_usage.get("configured_limit") or 0), 0)
+        remaining_count = max(int(welfare_usage.get("remaining_count") or 0), 0)
 
         stats = {
             "total_teams": team_stats["total"],
             "available_teams": team_stats["available"],
             "remaining_spots": remaining_spots,
             "welfare_code": welfare_code,
-            "welfare_code_limit": effective_limit,
+            "welfare_code_limit": configured_limit,
             "welfare_code_used": welfare_used,
-            "welfare_code_remaining": effective_limit,
+            "welfare_code_remaining": remaining_count,
         }
 
         return templates.TemplateResponse(
@@ -299,7 +300,7 @@ async def generate_welfare_common_code(
                 content={"success": False, "error": "当前没有可用的福利车位，无法生成通用兑换码"}
             )
 
-        current_welfare_code = (await settings_service.get_setting(db, "welfare_common_code", "") or "").strip()
+        current_welfare_code = (await settings_service.get_setting(db, "welfare_common_code", "", use_cache=False) or "").strip()
         max_attempts = 10
         code = None
         for _ in range(max_attempts):

--- a/app/services/redeem_flow.py
+++ b/app/services/redeem_flow.py
@@ -488,6 +488,26 @@ class RedeemFlowService:
                                         rc.warranty_expires_at = base_time + timedelta(days=days)
 
                             if is_virtual_welfare_code:
+                                current_welfare_code = (await settings_service.get_setting(
+                                    db_session,
+                                    "welfare_common_code",
+                                    "",
+                                    use_cache=False,
+                                ) or "").strip()
+                                if not current_welfare_code or current_welfare_code != code:
+                                    raise Exception("兑换码已失效，请刷新页面后使用最新福利通用兑换码")
+
+                                configured_limit_raw = await settings_service.get_setting(
+                                    db_session,
+                                    "welfare_common_code_limit",
+                                    "0",
+                                    use_cache=False,
+                                )
+                                try:
+                                    configured_limit = int(str(configured_limit_raw or "0").strip() or 0)
+                                except Exception:
+                                    configured_limit = 0
+
                                 setting_res = await db_session.execute(
                                     select(Setting)
                                     .where(Setting.key == "welfare_common_code_used_count")
@@ -500,16 +520,19 @@ class RedeemFlowService:
                                         current_used = int((used_setting.value or "0").strip() or 0)
                                     except Exception:
                                         current_used = 0
-                                    used_setting.value = str(current_used + 1)
                                 else:
+                                    current_used = 0
                                     used_setting = Setting(
                                         key="welfare_common_code_used_count",
-                                        value="1",
-                                        description="利通用兑换码已使用次数"
+                                        value="0",
+                                        description="福利通用兑换码已使用次数"
                                     )
                                     db_session.add(used_setting)
 
-                                # 同步更新缓存，避免下一次校验读取到旧值
+                                if configured_limit > 0 and current_used >= configured_limit:
+                                    raise Exception("兑换码次数已用完，无法进行兑换")
+
+                                used_setting.value = str(current_used + 1)
                                 settings_service._cache["welfare_common_code_used_count"] = used_setting.value
 
                             if is_virtual_welfare_code:

--- a/app/services/redemption.py
+++ b/app/services/redemption.py
@@ -11,7 +11,7 @@ from sqlalchemy import select, update, delete, and_, or_, func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.models import RedemptionCode, RedemptionRecord, Team
+from app.models import RedemptionCode, RedemptionRecord, Team, Setting
 from app.services.settings import (
     settings_service,
     WARRANTY_EXPIRATION_MODE_REFRESH_ON_REDEEM,
@@ -64,6 +64,14 @@ class RedemptionService:
         redemption_code.used_team_id = None
         redemption_code.used_at = None
         redemption_code.warranty_expires_at = None
+
+    @staticmethod
+    def _safe_int(value: Any, default: int = 0) -> int:
+        """安全地将 settings/查询结果转换为整数。"""
+        try:
+            return int(str(value).strip())
+        except Exception:
+            return default
 
     @staticmethod
     def _sync_code_status_fields(redemption_code: RedemptionCode) -> bool:
@@ -342,29 +350,54 @@ class RedemptionService:
     ) -> Dict[str, int | str | None]:
         """获取当前福利通用兑换码的实际使用情况。"""
         if welfare_code is None:
-            welfare_code = (await settings_service.get_setting(db_session, "welfare_common_code", "") or "").strip()
+            welfare_code = (await settings_service.get_setting(
+                db_session,
+                "welfare_common_code",
+                "",
+                use_cache=False,
+            ) or "").strip()
 
-        used_count = 0
-        if welfare_code:
-            used_result = await db_session.execute(
-                select(func.count(RedemptionRecord.id)).where(RedemptionRecord.code == welfare_code)
-            )
-            used_count = int(used_result.scalar() or 0)
+        used_setting_result = await db_session.execute(
+            select(Setting).where(Setting.key == "welfare_common_code_used_count")
+        )
+        used_setting = used_setting_result.scalar_one_or_none()
 
-        capacity_result = await db_session.execute(
+        if used_setting is not None:
+            used_count = self._safe_int(used_setting.value, 0)
+        else:
+            used_count = 0
+            if welfare_code:
+                used_result = await db_session.execute(
+                    select(func.count(RedemptionRecord.id)).where(RedemptionRecord.code == welfare_code)
+                )
+                used_count = int(used_result.scalar() or 0)
+
+        limit_result = await db_session.execute(
+            select(Setting).where(Setting.key == "welfare_common_code_limit")
+        )
+        limit_setting = limit_result.scalar_one_or_none()
+        configured_limit = self._safe_int(limit_setting.value if limit_setting else None, 0)
+
+        live_capacity_result = await db_session.execute(
             select(func.sum(Team.max_members - Team.current_members)).where(
                 Team.pool_type == "welfare",
                 Team.status == "active",
                 Team.current_members < Team.max_members
             )
         )
-        usable_capacity = int(capacity_result.scalar() or 0)
+        live_capacity = int(live_capacity_result.scalar() or 0)
+
+        effective_limit = configured_limit if configured_limit > 0 else live_capacity
+        remaining_by_limit = max(effective_limit - used_count, 0)
+        remaining_count = min(remaining_by_limit, live_capacity) if effective_limit > 0 else live_capacity
 
         return {
             "welfare_code": welfare_code,
             "used_count": used_count,
-            "usable_capacity": usable_capacity,
-            "remaining_count": usable_capacity,
+            "configured_limit": effective_limit,
+            "usable_capacity": live_capacity,
+            "remaining_count": remaining_count,
+            "remaining_by_limit": remaining_by_limit,
         }
 
     async def _rebuild_code_usage_state(
@@ -618,13 +651,19 @@ class RedemptionService:
         try:
             # 1. 优先按 settings 判断当前福利通用兑换码。
             # 即使数据库里存在用于兼容历史记录外键的影子码，也不能影响当前福利码的真实有效性。
-            welfare_code = (await settings_service.get_setting(db_session, "welfare_common_code", "") or "").strip()
+            welfare_code = (await settings_service.get_setting(
+                db_session,
+                "welfare_common_code",
+                "",
+                use_cache=False,
+            ) or "").strip()
             if welfare_code and code == welfare_code:
                 welfare_usage = await self.get_virtual_welfare_code_usage(db_session, welfare_code=welfare_code)
                 used_count = int(welfare_usage["used_count"] or 0)
-                effective_limit = int(welfare_usage["remaining_count"] or 0)
+                configured_limit = int(welfare_usage["configured_limit"] or 0)
+                remaining_count = int(welfare_usage["remaining_count"] or 0)
 
-                if effective_limit <= 0:
+                if configured_limit <= 0 or remaining_count <= 0:
                     return {
                         "success": True,
                         "valid": False,
@@ -648,8 +687,9 @@ class RedemptionService:
                         "pool_type": "welfare",
                         "reusable_by_seat": True,
                         "virtual_welfare_code": True,
-                        "limit": effective_limit,
+                        "limit": configured_limit,
                         "used_count": used_count,
+                        "remaining": remaining_count,
                     },
                     "error": None
                 }
@@ -664,9 +704,10 @@ class RedemptionService:
                 if welfare_code and code == welfare_code:
                     welfare_usage = await self.get_virtual_welfare_code_usage(db_session, welfare_code=welfare_code)
                     used_count = int(welfare_usage["used_count"] or 0)
-                    effective_limit = int(welfare_usage["remaining_count"] or 0)
+                    configured_limit = int(welfare_usage["configured_limit"] or 0)
+                    remaining_count = int(welfare_usage["remaining_count"] or 0)
 
-                    if effective_limit <= 0:
+                    if configured_limit <= 0 or remaining_count <= 0:
                         return {
                             "success": True,
                             "valid": False,
@@ -690,8 +731,9 @@ class RedemptionService:
                             "pool_type": "welfare",
                             "reusable_by_seat": True,
                             "virtual_welfare_code": True,
-                            "limit": effective_limit,
+                            "limit": configured_limit,
                             "used_count": used_count,
+                            "remaining": remaining_count,
                         },
                         "error": None
                     }

--- a/app/services/settings.py
+++ b/app/services/settings.py
@@ -49,7 +49,13 @@ class SettingsService:
             return normalized
         return DEFAULT_UI_THEME
 
-    async def get_setting(self, session: AsyncSession, key: str, default: Optional[str] = None) -> Optional[str]:
+    async def get_setting(
+        self,
+        session: AsyncSession,
+        key: str,
+        default: Optional[str] = None,
+        use_cache: bool = True,
+    ) -> Optional[str]:
         """
         获取单个配置项
 
@@ -57,12 +63,13 @@ class SettingsService:
             session: 数据库会话
             key: 配置项键名
             default: 默认值
+            use_cache: 是否优先使用进程内缓存
 
         Returns:
             配置项值,如果不存在则返回默认值
         """
         # 先从缓存获取
-        if key in self._cache:
+        if use_cache and key in self._cache:
             return self._cache[key]
 
         # 从数据库获取

--- a/app/services/team.py
+++ b/app/services/team.py
@@ -366,6 +366,41 @@ class TeamService:
         normalized = str(email).strip().lower()
         return normalized or None
 
+    async def _get_active_mapping_count(self, team_id: int, db_session: AsyncSession) -> int:
+        """统计本地仍占位的成员/邀请数量，用作同步时的人数下限。"""
+        result = await db_session.execute(
+            select(func.count(TeamEmailMapping.id)).where(
+                TeamEmailMapping.team_id == team_id,
+                TeamEmailMapping.status.in_(ACTIVE_TEAM_EMAIL_STATUSES),
+            )
+        )
+        return int(result.scalar() or 0)
+
+    async def _apply_member_count_floor(
+        self,
+        team: Team,
+        observed_member_count: int,
+        db_session: AsyncSession,
+    ) -> int:
+        """将远端同步人数、本地占位和当前人数合并，避免短暂同步延迟把人数回写变小。"""
+        await db_session.flush()
+        active_mapping_count = await self._get_active_mapping_count(team.id, db_session)
+        current_members = int(team.current_members or 0)
+        observed_count = int(observed_member_count or 0)
+        effective_members = max(current_members, observed_count, active_mapping_count)
+        if team.max_members and team.max_members > 0:
+            effective_members = min(effective_members, team.max_members)
+
+        team.current_members = effective_members
+        if team.expires_at and team.expires_at < get_now():
+            team.status = "expired"
+        elif team.current_members >= team.max_members:
+            team.status = "full"
+        else:
+            team.status = "active"
+
+        return effective_members
+
     async def get_active_team_ids_for_email(
         self,
         email: str,
@@ -1832,8 +1867,6 @@ class TeamService:
             team.subscription_plan = current_account["subscription_plan"]
             team.account_role = current_account.get("account_user_role")
             team.expires_at = expires_at
-            team.current_members = current_members
-            team.status = status
             team.device_code_auth_enabled = device_code_auth_enabled
             team.error_count = 0  # 同步成功，重置错误次数
             team.last_sync = get_now()
@@ -1843,14 +1876,15 @@ class TeamService:
                 invited_member_emails,
                 db_session
             )
+            effective_members = await self._apply_member_count_floor(team, current_members, db_session)
 
             await db_session.commit()
 
-            logger.info(f"Team 同步成功: ID {team_id}, 成员数 {current_members}")
+            logger.info(f"Team 同步成功: ID {team_id}, 成员数 {effective_members}")
 
             return {
                 "success": True,
-                "message": f"同步成功,当前成员数: {current_members}",
+                "message": f"同步成功,当前成员数: {effective_members}",
                 "member_emails": list(all_member_emails),
                 "error": None
             }
@@ -2149,16 +2183,10 @@ class TeamService:
             logger.info(f"获取 Team {team_id} 成员列表成功: 共 {len(all_members)} 个成员 (已加入: {members_result['total']})")
 
             # 6. 持久化最新人数，避免“查看成员/撤回时已拿到实时列表，但数据库人数仍旧值”
-            #    这会直接影响可用席位统计、active/full 状态判断，以及基于数据库的撤回后显示。
+            #    同时保留本地已预留/已邀请的人数下限，避免远端同步延迟把人数回写变小。
             live_member_count = len(all_members)
-            team.current_members = live_member_count
-            if team.expires_at and team.expires_at < get_now():
-                team.status = "expired"
-            elif team.current_members >= team.max_members:
-                team.status = "full"
-            else:
-                team.status = "active"
             team.last_sync = get_now()
+            effective_members = await self._apply_member_count_floor(team, live_member_count, db_session)
 
             # 7. 请求成功，重置错误状态
             await self._reset_error_status(team, db_session)
@@ -2166,7 +2194,7 @@ class TeamService:
             return {
                 "success": True,
                 "members": all_members,
-                "total": len(all_members),
+                "total": effective_members,
                 "error": None
             }
 

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -3361,3 +3361,161 @@ body.admin-theme .dropdown-menu {
         flex-wrap: wrap;
     }
 }
+
+@media (max-width: 640px) {
+    .mobile-card-table-container {
+        overflow: visible;
+        background: none;
+    }
+
+    .mobile-card-table-container .data-table,
+    .mobile-card-table-container .data-table tbody,
+    .mobile-card-table-container .data-table tr,
+    .mobile-card-table-container .data-table td {
+        display: block;
+        width: 100%;
+    }
+
+    .mobile-card-table-container .data-table {
+        white-space: normal;
+    }
+
+    .mobile-card-table-container .data-table thead {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+    }
+
+    .mobile-card-table-container .data-table tbody {
+        display: grid;
+        gap: 0.85rem;
+    }
+
+    .mobile-card-table-container .data-table tbody tr {
+        border: 1px solid var(--border-base);
+        border-radius: 18px;
+        background: color-mix(in srgb, var(--bg-surface) 86%, var(--bg-main) 14%);
+        box-shadow: var(--shadow-sm);
+        overflow: hidden;
+    }
+
+    .mobile-card-table-container .data-table tbody tr:hover td {
+        background: transparent;
+    }
+
+    .mobile-card-table-container .data-table td {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 0.85rem;
+        padding: 0.85rem 1rem;
+        border-bottom: 1px solid var(--border-base);
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
+        text-align: left !important;
+    }
+
+    .mobile-card-table-container .data-table td::before {
+        content: attr(data-label);
+        flex: 0 0 96px;
+        max-width: 96px;
+        color: var(--text-muted);
+        font-size: 0.76rem;
+        font-weight: 700;
+        letter-spacing: 0.02em;
+    }
+
+    .mobile-card-table-container .data-table td:last-child {
+        border-bottom: none;
+    }
+
+    .mobile-card-table-container .data-table td code,
+    .mobile-card-table-container .data-table td strong,
+    .mobile-card-table-container .data-table td span {
+        overflow-wrap: anywhere;
+    }
+
+    .mobile-card-table-container .data-table td.table-select-cell {
+        align-items: center;
+        justify-content: flex-start;
+        gap: 0.65rem;
+        background: color-mix(in srgb, var(--bg-main) 60%, var(--bg-surface) 40%);
+    }
+
+    .mobile-card-table-container .data-table td.table-select-cell::before {
+        flex-basis: auto;
+        max-width: none;
+    }
+
+    .mobile-card-table-container .data-table td.table-actions-cell {
+        display: block;
+        padding-top: 1rem;
+    }
+
+    .mobile-card-table-container .data-table td.table-actions-cell::before {
+        display: block;
+        max-width: none;
+        margin-bottom: 0.75rem;
+    }
+
+    .mobile-card-table-container .data-table td.table-actions-cell .action-buttons {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        justify-content: stretch !important;
+    }
+
+    .mobile-card-table-container .data-table td.table-actions-cell .btn {
+        flex: 1 1 100%;
+        width: 100%;
+    }
+
+    .mobile-card-table-container .data-table td.table-actions-cell .btn-icon {
+        flex: 0 0 auto;
+        width: 40px;
+        height: 40px;
+        min-height: 40px;
+    }
+
+    .mobile-card-table-container .pagination {
+        gap: 0.75rem;
+    }
+
+    .mobile-card-table-container .per-page-selector {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .mobile-card-table-container .pagination-controls {
+        width: 100%;
+        padding-inline: 0;
+    }
+
+    .search-form-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .search-form-grid .form-actions {
+        flex-direction: column;
+    }
+
+    .search-form-grid .form-actions .btn {
+        width: 100%;
+    }
+
+    .table-section-meta {
+        width: 100%;
+    }
+
+    .table-meta-pill {
+        width: 100%;
+        justify-content: center;
+    }
+}

--- a/app/templates/admin/codes/index.html
+++ b/app/templates/admin/codes/index.html
@@ -157,8 +157,8 @@
             </div>
 
             {% if codes %}
-            <div class="table-container">
-                <table class="data-table">
+            <div class="table-container mobile-card-table-container">
+                <table class="data-table mobile-card-table">
                     <thead>
                         <tr>
                             <th style="width: 40px;">
@@ -178,16 +178,16 @@
                     <tbody id="codesTableBody">
                         {% for code in codes %}
                         <tr data-status="{{ code.status }}">
-                            <td>
+                            <td class="table-select-cell" data-label="选择">
                                 <input type="checkbox" class="code-checkbox" value="{{ code.code }}" onchange="updateSelectionCount()" style="width: auto; margin: 0;">
                             </td>
-                            <td>
+                            <td data-label="兑换码">
                                 <div style="display: flex; align-items: center; gap: 0.5rem;">
                                     <i data-lucide="ticket" style="width: 14px; height: 14px; color: var(--text-muted);"></i>
                                     <code>{{ code.code }}</code>
                                 </div>
                             </td>
-                            <td>
+                            <td data-label="状态">
                                 {% if code.status == 'unused' %}
                                 <span class="status-badge status-active">未使用</span>
                                 {% elif code.status == 'used' %}
@@ -198,25 +198,25 @@
                                 <span class="status-badge status-error">已过期</span>
                                 {% endif %}
                             </td>
-                            <td>{{ code.created_at }}</td>
-                            <td>{{ code.expires_at if code.expires_at else '永久有效' }}</td>
-                            <td>{{ code.used_by_email if code.used_by_email else '-' }}</td>
-                            <td>{{ code.used_at if code.used_at else '-' }}</td>
-                            <td>
+                            <td data-label="创建时间">{{ code.created_at }}</td>
+                            <td data-label="过期时间">{{ code.expires_at if code.expires_at else '永久有效' }}</td>
+                            <td data-label="使用者邮箱">{{ code.used_by_email if code.used_by_email else '-' }}</td>
+                            <td data-label="使用时间">{{ code.used_at if code.used_at else '-' }}</td>
+                            <td data-label="质保">
                                 {% if code.has_warranty %}
                                 <span class="status-badge status-info">是</span>
                                 {% else %}
                                 <span class="status-badge" style="background: #f3f4f6; color: #6b7280;">否</span>
                                 {% endif %}
                             </td>
-                            <td>
+                            <td data-label="质保时长">
                                 {% if code.has_warranty %}
                                 <span style="font-size: 0.875rem;">{{ code.warranty_days }} 天</span>
                                 {% else %}
                                 -
                                 {% endif %}
                             </td>
-                            <td style="text-align: right;">
+                            <td class="table-actions-cell" data-label="操作" style="text-align: right;">
                                 <div class="action-buttons" style="justify-content: flex-end;">
                                     <button onclick='copyCode({{ code.code|tojson }})' class="btn btn-sm btn-icon btn-minimal btn-secondary" title="复制">
                                         <i data-lucide="copy" style="width: 14px; height: 14px;"></i>

--- a/app/templates/admin/records/index.html
+++ b/app/templates/admin/records/index.html
@@ -130,8 +130,8 @@
             </div>
 
             {% if records %}
-            <div class="table-container">
-                <table class="data-table">
+            <div class="table-container mobile-card-table-container">
+                <table class="data-table mobile-card-table">
                     <thead>
                         <tr>
                             <th>ID</th>
@@ -147,17 +147,19 @@
                     <tbody>
                         {% for record in records %}
                         <tr>
-                            <td><span class="text-muted">{{ record.id }}</span></td>
-                            <td><strong>{{ record.email }}</strong></td>
-                            <td><code>{{ record.code }}</code></td>
-                            <td>{{ record.team_name or '-' }}</td>
-                            <td><span class="badge badge-secondary">{{ record.team_id }}</span></td>
-                            <td><code class="account-id" title="{{ record.account_id }}">{{ record.account_id[:8] }}...</code></td>
-                            <td style="text-align: right;">{{ record.redeemed_at }}</td>
-                            <td style="text-align: right;">
-                                <button onclick='withdrawRecord({{ record.id|tojson }}, {{ record.email|tojson }}, this)' class="btn btn-sm btn-danger" title="撤回邀请并恢复兑换码">
-                                    <i data-lucide="undo-2" style="width: 14px; height: 14px;"></i> 撤回
-                                </button>
+                            <td data-label="ID"><span class="text-muted">{{ record.id }}</span></td>
+                            <td data-label="用户邮箱"><strong>{{ record.email }}</strong></td>
+                            <td data-label="兑换码"><code>{{ record.code }}</code></td>
+                            <td data-label="Team名称">{{ record.team_name or '-' }}</td>
+                            <td data-label="Team ID"><span class="badge badge-secondary">{{ record.team_id }}</span></td>
+                            <td data-label="Account ID"><code class="account-id" title="{{ record.account_id }}">{{ record.account_id[:8] }}...</code></td>
+                            <td data-label="兑换时间" style="text-align: right;">{{ record.redeemed_at }}</td>
+                            <td class="table-actions-cell" data-label="操作" style="text-align: right;">
+                                <div class="action-buttons" style="justify-content: flex-end;">
+                                    <button onclick='withdrawRecord({{ record.id|tojson }}, {{ record.email|tojson }}, this)' class="btn btn-sm btn-danger" title="撤回邀请并恢复兑换码">
+                                        <i data-lucide="undo-2" style="width: 14px; height: 14px;"></i> 撤回
+                                    </button>
+                                </div>
                             </td>
                         </tr>
                         {% endfor %}

--- a/tests/test_redeem_flow.py
+++ b/tests/test_redeem_flow.py
@@ -202,6 +202,53 @@ class RedeemFlowServiceTests(unittest.IsolatedAsyncioTestCase):
     async def _noop_async(*args, **kwargs):
         return None
 
+    @staticmethod
+    async def _return_token(*args, **kwargs):
+        return "token"
+
+    @staticmethod
+    async def _stub_account_info_success(*args, **kwargs):
+        return {
+            "success": True,
+            "accounts": [{
+                "account_id": "acct-64",
+                "name": "Floor Team",
+                "plan_type": "team",
+                "subscription_plan": "chatgpt-team",
+                "has_active_subscription": True,
+                "expires_at": None,
+                "account_user_role": "account-owner",
+            }],
+        }
+
+    @staticmethod
+    async def _stub_members_four(*args, **kwargs):
+        return {
+            "success": True,
+            "total": 4,
+            "members": [
+                {"email": "one@example.com"},
+                {"email": "two@example.com"},
+                {"email": "three@example.com"},
+                {"email": "four@example.com"},
+            ],
+        }
+
+    @staticmethod
+    async def _stub_empty_invites(*args, **kwargs):
+        return {
+            "success": True,
+            "total": 0,
+            "items": [],
+        }
+
+    @staticmethod
+    async def _stub_account_settings_success(*args, **kwargs):
+        return {
+            "success": True,
+            "data": {"beta_settings": {}},
+        }
+
     async def test_auto_select_skips_team_where_user_already_exists(self):
         await self._seed_basic_data()
         service = RedeemFlowService()
@@ -838,16 +885,21 @@ class RedeemFlowServiceTests(unittest.IsolatedAsyncioTestCase):
             ])
             await session.commit()
 
+            await settings_service.update_setting(session, "welfare_common_code_limit", "5")
+            await settings_service.update_setting(session, "welfare_common_code_used_count", "2")
+
             usage = await service.get_virtual_welfare_code_usage(session, welfare_code="WELF-CODE-001")
             self.assertEqual(usage["used_count"], 2)
+            self.assertEqual(usage["configured_limit"], 5)
             self.assertEqual(usage["usable_capacity"], 3)
             self.assertEqual(usage["remaining_count"], 3)
 
             result = await service.validate_code("WELF-CODE-001", session)
             self.assertTrue(result["success"])
             self.assertTrue(result["valid"])
-            self.assertEqual(result["redemption_code"]["limit"], 3)
+            self.assertEqual(result["redemption_code"]["limit"], 5)
             self.assertEqual(result["redemption_code"]["used_count"], 2)
+            self.assertEqual(result["redemption_code"]["remaining"], 3)
 
     async def test_virtual_welfare_code_handles_concurrent_redemptions_up_to_capacity(self):
         async with self.session_factory() as session:
@@ -858,7 +910,7 @@ class RedeemFlowServiceTests(unittest.IsolatedAsyncioTestCase):
                 account_id="acct-61",
                 team_name="Welfare Concurrent Team",
                 current_members=0,
-                max_members=5,
+                max_members=10,
                 status="active",
                 pool_type="welfare",
             )
@@ -868,6 +920,8 @@ class RedeemFlowServiceTests(unittest.IsolatedAsyncioTestCase):
             await session.commit()
             settings_service.clear_cache()
             await settings_service.update_setting(session, "welfare_common_code", "WELF-CONCURRENT-001")
+            await settings_service.update_setting(session, "welfare_common_code_limit", "5")
+            await settings_service.update_setting(session, "welfare_common_code_used_count", "0")
 
             service = RedeemFlowService()
             service.team_service = StubTeamService()
@@ -904,7 +958,7 @@ class RedeemFlowServiceTests(unittest.IsolatedAsyncioTestCase):
             async with self.session_factory() as verify_session:
                 stored_team = await verify_session.get(Team, 61)
                 self.assertEqual(stored_team.current_members, 5)
-                self.assertEqual(stored_team.status, "full")
+                self.assertEqual(stored_team.status, "active")
 
                 records = (
                     await verify_session.execute(
@@ -917,4 +971,162 @@ class RedeemFlowServiceTests(unittest.IsolatedAsyncioTestCase):
                     verify_session,
                     welfare_code="WELF-CONCURRENT-001",
                 )
+                self.assertEqual(usage["configured_limit"], 5)
                 self.assertEqual(usage["remaining_count"], 0)
+
+    async def test_virtual_welfare_code_stays_invalid_after_rotation_even_if_new_capacity_appears(self):
+        async with self.session_factory() as session:
+            old_team = Team(
+                id=62,
+                email="welfare-owner-62@example.com",
+                access_token_encrypted="token-62",
+                account_id="acct-62",
+                team_name="Old Welfare Team",
+                current_members=5,
+                max_members=5,
+                status="full",
+                pool_type="welfare",
+            )
+            session.add(old_team)
+            await session.commit()
+
+            service = RedemptionService()
+            await service.ensure_virtual_welfare_shadow_code(session, "OLD-WELF-CODE")
+            settings_service.clear_cache()
+            await settings_service.update_setting(session, "welfare_common_code", "OLD-WELF-CODE")
+            await settings_service.update_setting(session, "welfare_common_code_limit", "5")
+            await settings_service.update_setting(session, "welfare_common_code_used_count", "5")
+            await session.commit()
+
+            old_result = await service.validate_code("OLD-WELF-CODE", session)
+            self.assertTrue(old_result["success"])
+            self.assertFalse(old_result["valid"])
+
+            new_team = Team(
+                id=63,
+                email="welfare-owner-63@example.com",
+                access_token_encrypted="token-63",
+                account_id="acct-63",
+                team_name="New Welfare Team",
+                current_members=0,
+                max_members=5,
+                status="active",
+                pool_type="welfare",
+            )
+            session.add(new_team)
+            await session.commit()
+
+            await service.ensure_virtual_welfare_shadow_code(session, "NEW-WELF-CODE")
+            await settings_service.update_setting(session, "welfare_common_code", "NEW-WELF-CODE")
+            await settings_service.update_setting(session, "welfare_common_code_limit", "5")
+            await settings_service.update_setting(session, "welfare_common_code_used_count", "0")
+            await session.commit()
+
+            stale_result = await service.validate_code("OLD-WELF-CODE", session)
+            self.assertTrue(stale_result["success"])
+            self.assertFalse(stale_result["valid"])
+            self.assertIn("已失效", stale_result["reason"])
+
+            fresh_result = await service.validate_code("NEW-WELF-CODE", session)
+            self.assertTrue(fresh_result["success"])
+            self.assertTrue(fresh_result["valid"])
+            self.assertEqual(fresh_result["redemption_code"]["limit"], 5)
+            self.assertEqual(fresh_result["redemption_code"]["remaining"], 5)
+
+    async def test_virtual_welfare_code_limit_blocks_redemption_even_when_live_capacity_is_higher(self):
+        async with self.session_factory() as session:
+            welfare_team = Team(
+                id=65,
+                email="welfare-owner-65@example.com",
+                access_token_encrypted="token-65",
+                account_id="acct-65",
+                team_name="Large Welfare Team",
+                current_members=0,
+                max_members=10,
+                status="active",
+                pool_type="welfare",
+            )
+            session.add(welfare_team)
+            await session.commit()
+
+            service = RedemptionService()
+            await service.ensure_virtual_welfare_shadow_code(session, "WELF-LIMIT-001")
+            settings_service.clear_cache()
+            await settings_service.update_setting(session, "welfare_common_code", "WELF-LIMIT-001")
+            await settings_service.update_setting(session, "welfare_common_code_limit", "5")
+            await settings_service.update_setting(session, "welfare_common_code_used_count", "5")
+            await session.commit()
+
+            result = await service.validate_code("WELF-LIMIT-001", session)
+            self.assertTrue(result["success"])
+            self.assertFalse(result["valid"])
+            self.assertIn("次数已用完", result["reason"])
+
+    async def test_sync_team_info_keeps_local_member_floor_when_remote_count_is_stale(self):
+        async with self.session_factory() as session:
+            team = Team(
+                id=64,
+                email="welfare-owner-64@example.com",
+                access_token_encrypted="token-64",
+                account_id="acct-64",
+                team_name="Floor Team",
+                current_members=5,
+                max_members=5,
+                status="full",
+                pool_type="welfare",
+            )
+            session.add(team)
+            await session.commit()
+
+            team_service = TeamService()
+            await team_service.upsert_team_email_mapping(
+                team_id=64,
+                email="one@example.com",
+                status="joined",
+                db_session=session,
+                source="sync",
+            )
+            await team_service.upsert_team_email_mapping(
+                team_id=64,
+                email="two@example.com",
+                status="joined",
+                db_session=session,
+                source="sync",
+            )
+            await team_service.upsert_team_email_mapping(
+                team_id=64,
+                email="three@example.com",
+                status="joined",
+                db_session=session,
+                source="sync",
+            )
+            await team_service.upsert_team_email_mapping(
+                team_id=64,
+                email="four@example.com",
+                status="joined",
+                db_session=session,
+                source="sync",
+            )
+            await team_service.upsert_team_email_mapping(
+                team_id=64,
+                email="five@example.com",
+                status="invited",
+                db_session=session,
+                source="redeem",
+            )
+            await session.commit()
+
+            with patch.object(team_service, "ensure_access_token", new=self._return_token), \
+                 patch.object(team_service.chatgpt_service, "get_account_info", new=self._stub_account_info_success), \
+                 patch.object(team_service.chatgpt_service, "get_members", new=self._stub_members_four), \
+                 patch.object(team_service.chatgpt_service, "get_invites", new=self._stub_empty_invites), \
+                 patch.object(team_service.chatgpt_service, "get_account_settings", new=self._stub_account_settings_success):
+                result = await team_service.sync_team_info(64, session)
+
+            self.assertTrue(result["success"])
+            self.assertEqual(result["message"], "同步成功,当前成员数: 5")
+
+            self.assertTrue(result["success"])
+            refreshed_team = await session.get(Team, 64)
+            self.assertEqual(refreshed_team.current_members, 5)
+            self.assertEqual(refreshed_team.status, "full")


### PR DESCRIPTION
## Summary
- enforce welfare common code limits and re-check the active welfare code during redemption so stale codes and delayed syncs cannot oversell welfare seats
- keep local member-count floors during team syncs so remote lag does not reopen already reserved welfare capacity
- make the admin codes and records tables render as mobile-friendly cards while preserving existing filters, pagination, and actions

## Test plan
- [x] python -m pytest tests/test_redeem_flow.py -q
- [x] python -m py_compile app/routes/admin.py
- [x] parse admin/codes/index.html and admin/records/index.html with Jinja2
- [ ] manually verify /admin/codes and /admin/records at mobile widths after login
