### PR TITLE
fix(welfare): bind codes to selected team

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -89,6 +89,11 @@ class AddMemberRequest(BaseModel):
     email: str = Field(..., description="成员邮箱")
 
 
+class DeleteMemberRequest(BaseModel):
+    """删除成员请求"""
+    email: Optional[str] = Field(None, description="成员邮箱")
+
+
 class AddMembersRequest(BaseModel):
     """批量添加成员请求"""
     emails: List[str] = Field(..., description="成员邮箱列表")
@@ -102,6 +107,11 @@ class CodeGenerateRequest(BaseModel):
     expires_days: Optional[int] = Field(None, description="有效期天数")
     has_warranty: bool = Field(False, description="是否为质保兑换码")
     warranty_days: int = Field(30, description="质保天数")
+
+
+class WelfareCodeGenerateRequest(BaseModel):
+    """福利通用兑换码生成请求"""
+    team_id: int = Field(..., description="福利 Team ID")
 
 
 class TeamUpdateRequest(BaseModel):
@@ -257,6 +267,9 @@ async def welfare_dashboard(
             "welfare_code_limit": configured_limit,
             "welfare_code_used": welfare_used,
             "welfare_code_remaining": remaining_count,
+            "welfare_code_team_id": welfare_usage.get("team_id"),
+            "welfare_code_team_name": welfare_usage.get("team_name"),
+            "welfare_code_team_email": welfare_usage.get("team_email"),
         }
 
         return templates.TemplateResponse(
@@ -286,23 +299,39 @@ async def welfare_dashboard(
 
 @router.post("/welfare/code/generate")
 async def generate_welfare_common_code(
+    payload: WelfareCodeGenerateRequest,
     db: AsyncSession = Depends(get_db),
     current_user: dict = Depends(require_admin)
 ):
-    """生成/更新福利通用兑换码（不落库到 redemption_codes，仅存 settings）。"""
+    """为指定福利 Team 生成/更新当前唯一有效的通用兑换码。"""
     try:
-        seats_stmt = select(func.sum(Team.max_members - Team.current_members)).where(
-            Team.pool_type == "welfare",
-            Team.status == "active",
-            Team.current_members < Team.max_members
+        team_result = await db.execute(
+            select(Team).where(Team.id == payload.team_id)
         )
-        seats_result = await db.execute(seats_stmt)
-        total_seats = int(seats_result.scalar() or 0)
+        source_team = team_result.scalar_one_or_none()
+        if not source_team:
+            return JSONResponse(
+                status_code=status.HTTP_404_NOT_FOUND,
+                content={"success": False, "error": "指定的福利 Team 不存在"}
+            )
 
+        if source_team.pool_type != "welfare":
+            return JSONResponse(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                content={"success": False, "error": "只能为福利 Team 生成通用兑换码"}
+            )
+
+        if source_team.status != "active" or source_team.current_members >= source_team.max_members:
+            return JSONResponse(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                content={"success": False, "error": "该福利 Team 当前没有可用席位，无法生成通用兑换码"}
+            )
+
+        total_seats = max(int(source_team.max_members or 0) - int(source_team.current_members or 0), 0)
         if total_seats <= 0:
             return JSONResponse(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                content={"success": False, "error": "当前没有可用的福利车位，无法生成通用兑换码"}
+                content={"success": False, "error": "该福利 Team 当前没有可用席位，无法生成通用兑换码"}
             )
 
         current_welfare_code = (await settings_service.get_setting(db, "welfare_common_code", "", use_cache=False) or "").strip()
@@ -331,7 +360,6 @@ async def generate_welfare_common_code(
                 content={"success": False, "error": "生成福利通用兑换码失败，请重试"}
             )
 
-        # 兼容清理：历史版本可能把福利通用码写入 redemption_codes，这里统一失效处理
         await db.execute(
             update(RedemptionCode)
             .where(RedemptionCode.pool_type == "welfare", RedemptionCode.reusable_by_seat == True)
@@ -339,17 +367,32 @@ async def generate_welfare_common_code(
         )
         await db.commit()
 
-        # 每次生成新码都会立即替换旧码（旧码自动失效）
-        await settings_service.update_settings(db, {
+        updated = await settings_service.update_settings(db, {
             "welfare_common_code": code,
             "welfare_common_code_limit": str(total_seats),
             "welfare_common_code_used_count": "0",
-            "welfare_common_code_generated_at": get_now().isoformat()
+            "welfare_common_code_generated_at": get_now().isoformat(),
+            "welfare_common_code_team_id": str(source_team.id),
         })
+        if not updated:
+            await db.rollback()
+            return JSONResponse(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                content={"success": False, "error": "写入福利通用兑换码配置失败，请稍后重试"}
+            )
         await redemption_service.ensure_virtual_welfare_shadow_code(db, code)
         await db.commit()
 
-        return JSONResponse(content={"success": True, "code": code, "limit": total_seats, "used": 0, "remaining": total_seats})
+        return JSONResponse(content={
+            "success": True,
+            "code": code,
+            "limit": total_seats,
+            "used": 0,
+            "remaining": total_seats,
+            "team_id": source_team.id,
+            "team_email": source_team.email,
+            "team_name": source_team.team_name,
+        })
     except Exception as e:
         logger.exception("生成福利通用兑换码失败")
         return JSONResponse(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, content={"success": False, "error": "操作失败，请稍后重试"})
@@ -792,6 +835,7 @@ async def add_team_member(
 async def delete_team_member(
     team_id: int,
     user_id: str,
+    payload: DeleteMemberRequest,
     db: AsyncSession = Depends(get_db),
     current_user: dict = Depends(require_admin)
 ):
@@ -813,7 +857,8 @@ async def delete_team_member(
         result = await team_service.delete_team_member(
             team_id=team_id,
             user_id=user_id,
-            db_session=db
+            db_session=db,
+            email=payload.email,
         )
 
         if not result["success"]:

--- a/app/services/redeem_flow.py
+++ b/app/services/redeem_flow.py
@@ -85,24 +85,69 @@ class RedeemFlowService:
             # 2. 获取可用 Team 列表
             code_meta = validate_result.get("redemption_code") or {}
             pool_type = code_meta.get("pool_type", "normal")
-            teams_result = await self.team_service.get_available_teams(db_session, pool_type=pool_type)
+            teams: List[Dict[str, Any]] = []
+            if code_meta.get("virtual_welfare_code"):
+                bound_team_id = int(code_meta.get("team_id") or 0)
+                if bound_team_id <= 0:
+                    return {
+                        "success": True,
+                        "valid": False,
+                        "reason": "福利通用兑换码未绑定有效 Team，请联系管理员重新生成",
+                        "teams": [],
+                        "error": None
+                    }
 
-            if not teams_result["success"]:
-                return {
-                    "success": False,
-                    "valid": True,
-                    "reason": "兑换码有效",
-                    "teams": [],
-                    "error": teams_result["error"]
-                }
+                team_result = await self.team_service.get_team_by_id(bound_team_id, db_session)
+                if not team_result.get("success"):
+                    return {
+                        "success": True,
+                        "valid": False,
+                        "reason": "福利通用兑换码绑定的 Team 不存在，请联系管理员重新生成",
+                        "teams": [],
+                        "error": None
+                    }
 
-            logger.info(f"验证兑换码成功: {code}, 可用 Team 数量: {len(teams_result['teams'])}")
+                bound_team = team_result.get("team") or {}
+                if (
+                    bound_team.get("status") != "active"
+                    or int(bound_team.get("current_members") or 0) >= int(bound_team.get("max_members") or 0)
+                ):
+                    return {
+                        "success": True,
+                        "valid": False,
+                        "reason": "福利通用兑换码绑定的 Team 当前不可用，请联系管理员重新生成",
+                        "teams": [],
+                        "error": None
+                    }
+
+                teams = [{
+                    "id": bound_team["id"],
+                    "team_name": bound_team.get("team_name"),
+                    "current_members": bound_team.get("current_members"),
+                    "max_members": bound_team.get("max_members"),
+                    "expires_at": bound_team.get("expires_at"),
+                    "subscription_plan": bound_team.get("subscription_plan"),
+                }]
+            else:
+                teams_result = await self.team_service.get_available_teams(db_session, pool_type=pool_type)
+
+                if not teams_result["success"]:
+                    return {
+                        "success": False,
+                        "valid": True,
+                        "reason": "兑换码有效",
+                        "teams": [],
+                        "error": teams_result["error"]
+                    }
+                teams = teams_result["teams"]
+
+            logger.info(f"验证兑换码成功: {code}, 可用 Team 数量: {len(teams)}")
 
             return {
                 "success": True,
                 "valid": True,
                 "reason": "兑换码有效",
-                "teams": teams_result["teams"],
+                "teams": teams,
                 "error": None
             }
 
@@ -218,6 +263,10 @@ class RedeemFlowService:
                     code_meta = validate_result.get("redemption_code") or {}
                     pool_type = code_meta.get("pool_type", "normal")
                     is_virtual_welfare_code = bool(code_meta.get("virtual_welfare_code"))
+                    bound_welfare_team_id = int(code_meta.get("team_id") or 0) if is_virtual_welfare_code else 0
+
+                    if is_virtual_welfare_code and bound_welfare_team_id <= 0:
+                        return {"success": False, "error": "福利通用兑换码未绑定有效 Team，请联系管理员重新生成"}
 
                     if selected_team_locked:
                         existing_team_ids = set(
@@ -237,18 +286,24 @@ class RedeemFlowService:
                             }
 
                     # 确定目标 Team (初选)
-                    team_id_final = current_target_team_id
-                    if not team_id_final:
-                        select_res = await self.select_team_auto(
-                            db_session,
-                            email=email,
-                            exclude_team_ids=sorted(excluded_team_ids) if excluded_team_ids else None,
-                            pool_type=pool_type
-                        )
-                        if not select_res["success"]:
-                            return {"success": False, "error": select_res["error"]}
-                        team_id_final = select_res["team_id"]
-                        current_target_team_id = team_id_final
+                    if is_virtual_welfare_code:
+                        if selected_team_locked and current_target_team_id != bound_welfare_team_id:
+                            return {"success": False, "error": "当前福利通用兑换码仅可兑换到其绑定的 Team"}
+                        team_id_final = bound_welfare_team_id
+                        current_target_team_id = bound_welfare_team_id
+                    else:
+                        team_id_final = current_target_team_id
+                        if not team_id_final:
+                            select_res = await self.select_team_auto(
+                                db_session,
+                                email=email,
+                                exclude_team_ids=sorted(excluded_team_ids) if excluded_team_ids else None,
+                                pool_type=pool_type
+                            )
+                            if not select_res["success"]:
+                                return {"success": False, "error": select_res["error"]}
+                            team_id_final = select_res["team_id"]
+                            current_target_team_id = team_id_final
 
                     # 使用 Team 锁序列化对该账户的操作，防止并发冲突
                     async with _team_locks[team_id_final]:
@@ -496,6 +551,19 @@ class RedeemFlowService:
                                 ) or "").strip()
                                 if not current_welfare_code or current_welfare_code != code:
                                     raise Exception("兑换码已失效，请刷新页面后使用最新福利通用兑换码")
+
+                                bound_team_id_raw = await settings_service.get_setting(
+                                    db_session,
+                                    "welfare_common_code_team_id",
+                                    "0",
+                                    use_cache=False,
+                                )
+                                try:
+                                    current_bound_team_id = int(str(bound_team_id_raw or "0").strip() or 0)
+                                except Exception:
+                                    current_bound_team_id = 0
+                                if current_bound_team_id <= 0 or current_bound_team_id != team_id_final:
+                                    raise Exception("当前福利通用兑换码仅可兑换到其绑定的 Team")
 
                                 configured_limit_raw = await settings_service.get_setting(
                                     db_session,

--- a/app/services/redemption.py
+++ b/app/services/redemption.py
@@ -357,6 +357,31 @@ class RedemptionService:
                 use_cache=False,
             ) or "").strip()
 
+        team_id_raw = await settings_service.get_setting(
+            db_session,
+            "welfare_common_code_team_id",
+            "",
+            use_cache=False,
+        )
+        source_team_id = self._safe_int(team_id_raw, 0)
+        source_team: Optional[Team] = None
+        if source_team_id > 0:
+            source_team = await db_session.get(Team, source_team_id)
+
+        if source_team is None and welfare_code and source_team_id <= 0:
+            fallback_team_result = await db_session.execute(
+                select(Team)
+                .join(RedemptionRecord, RedemptionRecord.team_id == Team.id)
+                .where(
+                    RedemptionRecord.code == welfare_code,
+                    Team.pool_type == "welfare",
+                )
+                .order_by(RedemptionRecord.redeemed_at.desc(), RedemptionRecord.id.desc())
+            )
+            source_team = fallback_team_result.scalars().first()
+            if source_team is not None:
+                source_team_id = int(source_team.id)
+
         used_setting_result = await db_session.execute(
             select(Setting).where(Setting.key == "welfare_common_code_used_count")
         )
@@ -378,14 +403,14 @@ class RedemptionService:
         limit_setting = limit_result.scalar_one_or_none()
         configured_limit = self._safe_int(limit_setting.value if limit_setting else None, 0)
 
-        live_capacity_result = await db_session.execute(
-            select(func.sum(Team.max_members - Team.current_members)).where(
-                Team.pool_type == "welfare",
-                Team.status == "active",
-                Team.current_members < Team.max_members
-            )
-        )
-        live_capacity = int(live_capacity_result.scalar() or 0)
+        live_capacity = 0
+        if (
+            source_team
+            and source_team.pool_type == "welfare"
+            and source_team.status == "active"
+            and int(source_team.current_members or 0) < int(source_team.max_members or 0)
+        ):
+            live_capacity = max(int(source_team.max_members or 0) - int(source_team.current_members or 0), 0)
 
         effective_limit = configured_limit if configured_limit > 0 else live_capacity
         remaining_by_limit = max(effective_limit - used_count, 0)
@@ -398,6 +423,9 @@ class RedemptionService:
             "usable_capacity": live_capacity,
             "remaining_count": remaining_count,
             "remaining_by_limit": remaining_by_limit,
+            "team_id": source_team.id if source_team else None,
+            "team_name": source_team.team_name if source_team else None,
+            "team_email": source_team.email if source_team else None,
         }
 
     async def _rebuild_code_usage_state(
@@ -663,6 +691,16 @@ class RedemptionService:
                 configured_limit = int(welfare_usage["configured_limit"] or 0)
                 remaining_count = int(welfare_usage["remaining_count"] or 0)
 
+                source_team_id = self._safe_int(welfare_usage.get("team_id"), 0)
+                if source_team_id <= 0:
+                    return {
+                        "success": True,
+                        "valid": False,
+                        "reason": "福利通用兑换码未绑定有效 Team，请联系管理员重新生成",
+                        "redemption_code": None,
+                        "error": None
+                    }
+
                 if configured_limit <= 0 or remaining_count <= 0:
                     return {
                         "success": True,
@@ -690,6 +728,9 @@ class RedemptionService:
                         "limit": configured_limit,
                         "used_count": used_count,
                         "remaining": remaining_count,
+                        "team_id": source_team_id,
+                        "team_name": welfare_usage.get("team_name"),
+                        "team_email": welfare_usage.get("team_email"),
                     },
                     "error": None
                 }
@@ -706,6 +747,16 @@ class RedemptionService:
                     used_count = int(welfare_usage["used_count"] or 0)
                     configured_limit = int(welfare_usage["configured_limit"] or 0)
                     remaining_count = int(welfare_usage["remaining_count"] or 0)
+
+                    source_team_id = self._safe_int(welfare_usage.get("team_id"), 0)
+                    if source_team_id <= 0:
+                        return {
+                            "success": True,
+                            "valid": False,
+                            "reason": "福利通用兑换码未绑定有效 Team，请联系管理员重新生成",
+                            "redemption_code": None,
+                            "error": None
+                        }
 
                     if configured_limit <= 0 or remaining_count <= 0:
                         return {
@@ -734,6 +785,9 @@ class RedemptionService:
                             "limit": configured_limit,
                             "used_count": used_count,
                             "remaining": remaining_count,
+                            "team_id": source_team_id,
+                            "team_name": welfare_usage.get("team_name"),
+                            "team_email": welfare_usage.get("team_email"),
                         },
                         "error": None
                     }

--- a/app/services/team.py
+++ b/app/services/team.py
@@ -366,6 +366,38 @@ class TeamService:
         normalized = str(email).strip().lower()
         return normalized or None
 
+    def _filter_pending_invites(
+        self,
+        invite_items: Optional[List[Dict[str, Any]]],
+        joined_emails: Optional[set[str]] = None,
+    ) -> List[Dict[str, Any]]:
+        """过滤仍占位的待加入邀请，并剔除与已加入成员重复的邮箱。"""
+        normalized_joined = {
+            email for email in (joined_emails or set()) if email
+        }
+        active_invite_statuses = {"pending", "invited", "sent", "open", "active"}
+        pending_items: List[Dict[str, Any]] = []
+
+        for invite in invite_items or []:
+            email = self._normalize_member_email(
+                invite.get("email_address") or invite.get("email")
+            )
+            if not email or email in normalized_joined:
+                continue
+
+            raw_status = str(
+                invite.get("status")
+                or invite.get("invite_status")
+                or invite.get("state")
+                or ""
+            ).strip().lower()
+            if raw_status and raw_status not in active_invite_statuses:
+                continue
+
+            pending_items.append({**invite, "email_address": email})
+
+        return pending_items
+
     async def _get_active_mapping_count(self, team_id: int, db_session: AsyncSession) -> int:
         """统计本地仍占位的成员/邀请数量，用作同步时的人数下限。"""
         result = await db_session.execute(
@@ -382,12 +414,11 @@ class TeamService:
         observed_member_count: int,
         db_session: AsyncSession,
     ) -> int:
-        """将远端同步人数、本地占位和当前人数合并，避免短暂同步延迟把人数回写变小。"""
+        """将远端同步人数与本地仍活跃占位合并，避免短暂同步延迟把人数回写变小。"""
         await db_session.flush()
         active_mapping_count = await self._get_active_mapping_count(team.id, db_session)
-        current_members = int(team.current_members or 0)
         observed_count = int(observed_member_count or 0)
-        effective_members = max(current_members, observed_count, active_mapping_count)
+        effective_members = max(observed_count, active_mapping_count)
         if team.max_members and team.max_members > 0:
             effective_members = min(effective_members, team.max_members)
 
@@ -1810,13 +1841,16 @@ class TeamService:
                 }
 
             if invites_result["success"]:
-                current_members += invites_result["total"]
-                for inv in invites_result.get("items", []):
-                    if inv.get("email_address"):
-                        normalized_email = self._normalize_member_email(inv["email_address"])
-                        if normalized_email:
-                            invited_member_emails.add(normalized_email)
-                            all_member_emails.add(normalized_email)
+                pending_invites = self._filter_pending_invites(
+                    invites_result.get("items", []),
+                    joined_emails=joined_member_emails,
+                )
+                current_members += len(pending_invites)
+                for inv in pending_invites:
+                    normalized_email = inv.get("email_address")
+                    if normalized_email:
+                        invited_member_emails.add(normalized_email)
+                        all_member_emails.add(normalized_email)
             else:
                 # 检查是否封号或 Token 失效
                 if await self._handle_api_error(invites_result, team, db_session):
@@ -2156,21 +2190,29 @@ class TeamService:
 
             # 5. 合并列表并统一格式
             all_members = []
-            
+            joined_emails: set[str] = set()
+
             # 处理已加入成员
             for m in members_result["members"]:
+                normalized_email = self._normalize_member_email(m.get("email"))
+                if normalized_email:
+                    joined_emails.add(normalized_email)
                 all_members.append({
                     "user_id": m.get("id"),
-                    "email": m.get("email"),
+                    "email": normalized_email or m.get("email"),
                     "name": m.get("name"),
                     "role": m.get("role"),
                     "added_at": m.get("created_time"),
                     "status": "joined"
                 })
-            
+
             # 处理待加入成员
             if invites_result["success"]:
-                for inv in invites_result["items"]:
+                pending_invites = self._filter_pending_invites(
+                    invites_result.get("items", []),
+                    joined_emails=joined_emails,
+                )
+                for inv in pending_invites:
                     all_members.append({
                         "user_id": None, # 邀请还没有 user_id
                         "email": inv.get("email_address"),
@@ -2183,7 +2225,6 @@ class TeamService:
             logger.info(f"获取 Team {team_id} 成员列表成功: 共 {len(all_members)} 个成员 (已加入: {members_result['total']})")
 
             # 6. 持久化最新人数，避免“查看成员/撤回时已拿到实时列表，但数据库人数仍旧值”
-            #    同时保留本地已预留/已邀请的人数下限，避免远端同步延迟把人数回写变小。
             live_member_count = len(all_members)
             team.last_sync = get_now()
             effective_members = await self._apply_member_count_floor(team, live_member_count, db_session)

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -1768,7 +1768,8 @@ async function deleteMember(teamId, userId, email, inModal = false) {
     try {
         showToast('正在删除...', 'info');
         const result = await apiCall(`/admin/teams/${teamId}/members/${userId}/delete`, {
-            method: 'POST'
+            method: 'POST',
+            body: JSON.stringify({ email })
         });
 
         if (result.success) {
@@ -1793,40 +1794,85 @@ if (typeof window !== 'undefined') {
     window.parseOAuthCallbackAndFill = parseOAuthCallbackAndFill;
     window.handleJsonFileImport = handleJsonFileImport;
     window.copyWelfareCode = copyWelfareCode;
+    window.updateWelfareCodeTeamHint = updateWelfareCodeTeamHint;
 }
 
 
+function updateWelfareCodeTeamHint() {
+    const select = document.getElementById('welfareCodeTeamSelect');
+    const hint = document.getElementById('welfareCodeTeamHint');
+    if (!select || !hint) return;
+
+    const option = select.options[select.selectedIndex];
+    if (!option || !option.value) {
+        hint.textContent = '请选择要作为号池的福利 Team。';
+        return;
+    }
+
+    const teamName = option.dataset.teamName || option.textContent || '';
+    const teamEmail = option.dataset.teamEmail || '';
+    const remaining = option.dataset.remaining || '0';
+    hint.textContent = `将为 ${teamName}${teamEmail ? `（${teamEmail}）` : ''} 生成兑换码，当前剩余可用次数 ${remaining}。`;
+}
+
 async function generateWelfareCode() {
+    const pageBtn = document.getElementById('generateWelfareCodeBtn');
+    const confirmBtn = document.getElementById('confirmGenerateWelfareCodeBtn');
+    const teamSelect = document.getElementById('welfareCodeTeamSelect');
+    const selectedTeamId = teamSelect ? Number(teamSelect.value || 0) : 0;
+
+    if (!selectedTeamId) {
+        showToast('请先选择一个福利 Team', 'error');
+        return;
+    }
+
     try {
-        const btn = document.getElementById('generateWelfareCodeBtn');
-        if (btn) { btn.disabled = true; }
-        const result = await apiCall('/admin/welfare/code/generate', { method: 'POST' });
+        if (pageBtn) pageBtn.disabled = true;
+        if (confirmBtn) confirmBtn.disabled = true;
+
+        const result = await apiCall('/admin/welfare/code/generate', {
+            method: 'POST',
+            body: JSON.stringify({ team_id: selectedTeamId })
+        });
         if (!result.success) throw new Error(result.error || '生成失败');
 
+        const payload = result.data || {};
+        const newCode = payload.code || '';
+        const used = typeof payload.used === 'number' ? payload.used : 0;
+        const limit = typeof payload.limit === 'number' ? payload.limit : 0;
+        const remaining = typeof payload.remaining === 'number' ? payload.remaining : Math.max(limit - used, 0);
+        const teamName = payload.team_name || '';
+        const teamEmail = payload.team_email || '';
+
         const codeValueEl = document.getElementById('welfareCommonCodeValue');
-        const newCode = result.code || '';
         if (codeValueEl) codeValueEl.value = newCode;
 
         const codeTextEl = document.getElementById('welfareCommonCodeText');
-        if (codeTextEl) { codeTextEl.textContent = newCode || '-'; codeTextEl.title = newCode || ''; }
+        if (codeTextEl) {
+            codeTextEl.textContent = newCode || '-';
+            codeTextEl.title = newCode || '';
+        }
 
         const usageTextEl = document.getElementById('welfareCodeUsageText');
         if (usageTextEl) {
-            const used = typeof result.used === 'number' ? result.used : 0;
-            const limit = typeof result.limit === 'number' ? result.limit : 0;
-            const remaining = typeof result.remaining === 'number' ? result.remaining : Math.max(limit - used, 0);
             usageTextEl.textContent = `剩余次数 ${remaining} / ${limit}`;
         }
 
-        const copyBtn = document.getElementById('copyWelfareCodeBtn');
-        if (copyBtn) copyBtn.disabled = !result.code;
+        const sourceTextEl = document.getElementById('welfareCodeSourceTeamText');
+        if (sourceTextEl) {
+            sourceTextEl.textContent = `来源 Team：${teamName || ('#' + selectedTeamId)}${teamEmail ? `（${teamEmail}）` : ''}`;
+        }
 
-        await copyToClipboard(result.code || '');
-        showToast(`通用兑换码已更新并复制，剩余次数 ${result.remaining}/${result.limit}`, 'success');
+        const copyBtn = document.getElementById('copyWelfareCodeBtn');
+        if (copyBtn) copyBtn.disabled = !newCode;
+
+        hideModal('welfareCodeTeamModal');
+        await copyToClipboard(newCode || '');
+        showToast(`通用兑换码已更新并复制，剩余次数 ${remaining}/${limit}`, 'success');
     } catch (error) {
         showToast(getFriendlyAdminErrorMessage(error.message || '生成通用兑换码失败', 0, 'common'), 'error');
     } finally {
-        const btn = document.getElementById('generateWelfareCodeBtn');
-        if (btn) btn.disabled = false;
+        if (pageBtn) pageBtn.disabled = false;
+        if (confirmBtn) confirmBtn.disabled = false;
     }
 }

--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -684,7 +684,7 @@
         </div>
         <div class="page-header-actions">
             {% if active_page == "welfare" %}
-            <button type="button" class="btn btn-secondary" onclick="generateWelfareCode()" id="generateWelfareCodeBtn">
+            <button type="button" class="btn btn-secondary" onclick="showModal('welfareCodeTeamModal')" id="generateWelfareCodeBtn">
                 <i data-lucide="ticket-plus" style="width: 16px; height: 16px;"></i> 生成通用兑换码
             </button>
             {% endif %}
@@ -723,6 +723,13 @@
                 <div class="stat-label">通用兑换码</div>
                 <div class="welfare-code-value" id="welfareCommonCodeText" title="{{ stats.welfare_code or '' }}">{{ stats.welfare_code or '-' }}</div>
                 <div class="stat-sub-label" id="welfareCodeUsageText">剩余次数 {{ stats.welfare_code_remaining }} / {{ stats.welfare_code_limit }}</div>
+                <div class="stat-sub-label" id="welfareCodeSourceTeamText">
+                    {% if stats.welfare_code_team_id %}
+                    来源 Team：{{ stats.welfare_code_team_name or ('#' ~ stats.welfare_code_team_id) }}{% if stats.welfare_code_team_email %}（{{ stats.welfare_code_team_email }}）{% endif %}
+                    {% else %}
+                    来源 Team：未绑定
+                    {% endif %}
+                </div>
                 <div class="welfare-code-row">
                     <button type="button" class="btn btn-secondary btn-sm" onclick="copyWelfareCode()" {% if not stats.welfare_code %}disabled{% endif %} id="copyWelfareCodeBtn">
                         <i data-lucide="copy" style="width: 14px; height: 14px;"></i> 复制兑换码
@@ -1095,6 +1102,41 @@
     </div>
 </div>
 
+{% if active_page == "welfare" %}
+<div id="welfareCodeTeamModal" class="modal-overlay">
+    <div class="modal">
+        <div class="modal-header">
+            <h3>选择福利 Team 号池</h3>
+            <button class="modal-close" onclick="hideModal('welfareCodeTeamModal')">&times;</button>
+        </div>
+        <div class="modal-body">
+            <div class="form-group">
+                <label for="welfareCodeTeamSelect">福利 Team</label>
+                <select id="welfareCodeTeamSelect" class="form-control" onchange="updateWelfareCodeTeamHint()">
+                    <option value="">请选择一个福利 Team</option>
+                    {% for team in teams %}
+                    {% set available_slots = team.max_members - team.current_members %}
+                    {% if team.status == 'active' and available_slots > 0 %}
+                    <option
+                        value="{{ team.id }}"
+                        data-team-name="{{ team.team_name or '' }}"
+                        data-team-email="{{ team.email }}"
+                        data-remaining="{{ available_slots }}"
+                    >{{ team.team_name or ('Team #' ~ team.id) }}（{{ team.email }}，剩余 {{ available_slots }}）</option>
+                    {% endif %}
+                    {% endfor %}
+                </select>
+            </div>
+            <div id="welfareCodeTeamHint" class="text-muted small" style="margin-bottom: 1rem;">请选择要作为号池的福利 Team。</div>
+            <div class="modal-actions" style="display:flex; justify-content:flex-end; gap:0.75rem;">
+                <button type="button" class="btn btn-secondary" onclick="hideModal('welfareCodeTeamModal')">取消</button>
+                <button type="button" class="btn btn-primary" id="confirmGenerateWelfareCodeBtn" onclick="generateWelfareCode()">生成兑换码</button>
+            </div>
+        </div>
+    </div>
+</div>
+{% endif %}
+
 <!-- 编辑 Team 模态框 -->
 <div id="editTeamModal" class="modal-overlay">
     <div class="modal">
@@ -1200,6 +1242,11 @@
         const editTeamModal = document.getElementById('editTeamModal');
         if (editTeamModal && editTeamModal.parentElement !== document.body) {
             document.body.appendChild(editTeamModal);
+        }
+
+        const welfareCodeTeamModal = document.getElementById('welfareCodeTeamModal');
+        if (welfareCodeTeamModal && welfareCodeTeamModal.parentElement !== document.body) {
+            document.body.appendChild(welfareCodeTeamModal);
         }
 
         // Ensure floating dropdowns are mounted to body for fixed positioning

--- a/tests/test_redeem_flow.py
+++ b/tests/test_redeem_flow.py
@@ -1,19 +1,22 @@
 import asyncio
+import json
 import unittest
 from datetime import timedelta
 from unittest.mock import patch
 
 from sqlalchemy import select
+from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.database import Base
-from app.models import RedemptionCode, RedemptionRecord, Team, TeamEmailMapping
+from app.models import RedemptionCode, RedemptionRecord, Team, TeamEmailMapping, Setting
 from app.services.redeem_flow import RedeemFlowService
 from app.services.notification import notification_service
 from app.services.redemption import RedemptionService
 from app.services.settings import settings_service
 from app.services.team import TeamService
 from app.services.warranty import WarrantyService
+from app.routes.admin import generate_welfare_common_code, WelfareCodeGenerateRequest
 from app.utils.time_utils import get_now
 
 
@@ -1047,6 +1050,7 @@ class RedeemFlowServiceTests(unittest.IsolatedAsyncioTestCase):
             await service.ensure_virtual_welfare_shadow_code(session, "WELF-CODE-001")
             settings_service.clear_cache()
             await settings_service.update_setting(session, "welfare_common_code", "WELF-CODE-001")
+            await settings_service.update_setting(session, "welfare_common_code_team_id", "60")
             session.add_all([
                 RedemptionRecord(
                     email="one@example.com",
@@ -1100,6 +1104,7 @@ class RedeemFlowServiceTests(unittest.IsolatedAsyncioTestCase):
             await settings_service.update_setting(session, "welfare_common_code", "WELF-CONCURRENT-001")
             await settings_service.update_setting(session, "welfare_common_code_limit", "5")
             await settings_service.update_setting(session, "welfare_common_code_used_count", "0")
+            await settings_service.update_setting(session, "welfare_common_code_team_id", "61")
 
             service = RedeemFlowService()
             service.team_service = StubTeamService()
@@ -1174,6 +1179,7 @@ class RedeemFlowServiceTests(unittest.IsolatedAsyncioTestCase):
             await settings_service.update_setting(session, "welfare_common_code", "OLD-WELF-CODE")
             await settings_service.update_setting(session, "welfare_common_code_limit", "5")
             await settings_service.update_setting(session, "welfare_common_code_used_count", "5")
+            await settings_service.update_setting(session, "welfare_common_code_team_id", "62")
             await session.commit()
 
             old_result = await service.validate_code("OLD-WELF-CODE", session)
@@ -1198,6 +1204,7 @@ class RedeemFlowServiceTests(unittest.IsolatedAsyncioTestCase):
             await settings_service.update_setting(session, "welfare_common_code", "NEW-WELF-CODE")
             await settings_service.update_setting(session, "welfare_common_code_limit", "5")
             await settings_service.update_setting(session, "welfare_common_code_used_count", "0")
+            await settings_service.update_setting(session, "welfare_common_code_team_id", "63")
             await session.commit()
 
             stale_result = await service.validate_code("OLD-WELF-CODE", session)
@@ -1233,6 +1240,7 @@ class RedeemFlowServiceTests(unittest.IsolatedAsyncioTestCase):
             await settings_service.update_setting(session, "welfare_common_code", "WELF-LIMIT-001")
             await settings_service.update_setting(session, "welfare_common_code_limit", "5")
             await settings_service.update_setting(session, "welfare_common_code_used_count", "5")
+            await settings_service.update_setting(session, "welfare_common_code_team_id", "65")
             await session.commit()
 
             result = await service.validate_code("WELF-LIMIT-001", session)
@@ -1308,3 +1316,288 @@ class RedeemFlowServiceTests(unittest.IsolatedAsyncioTestCase):
             refreshed_team = await session.get(Team, 64)
             self.assertEqual(refreshed_team.current_members, 5)
             self.assertEqual(refreshed_team.status, "full")
+
+    async def test_apply_member_count_floor_allows_count_to_fall_after_mapping_removed(self):
+        async with self.session_factory() as session:
+            team = Team(
+                id=66,
+                email="welfare-owner-66@example.com",
+                access_token_encrypted="token-66",
+                account_id="acct-66",
+                team_name="Falling Team",
+                current_members=3,
+                max_members=5,
+                status="active",
+                pool_type="welfare",
+            )
+            session.add(team)
+            await session.commit()
+
+            team_service = TeamService()
+            await team_service.upsert_team_email_mapping(66, "one@example.com", "joined", session, source="sync")
+            await team_service.upsert_team_email_mapping(66, "two@example.com", "joined", session, source="sync")
+            await team_service.mark_team_email_mapping_removed(66, "three@example.com", session, source="api")
+            await session.commit()
+
+            effective_members = await team_service._apply_member_count_floor(team, 2, session)
+            await session.commit()
+
+            self.assertEqual(effective_members, 2)
+            refreshed_team = await session.get(Team, 66)
+            self.assertEqual(refreshed_team.current_members, 2)
+            self.assertEqual(refreshed_team.status, "active")
+
+    async def test_get_team_members_filters_non_pending_invites_and_joined_duplicates(self):
+        async with self.session_factory() as session:
+            team = Team(
+                id=67,
+                email="welfare-owner-67@example.com",
+                access_token_encrypted="token-67",
+                account_id="acct-67",
+                team_name="Invite Filter Team",
+                current_members=3,
+                max_members=6,
+                status="active",
+                pool_type="welfare",
+            )
+            session.add(team)
+            await session.commit()
+
+            team_service = TeamService()
+
+            async def stub_members(*args, **kwargs):
+                return {
+                    "success": True,
+                    "total": 2,
+                    "members": [
+                        {"id": "u1", "email": "joined@example.com", "role": "standard-user", "created_time": "2026-04-16T08:00:00"},
+                        {"id": "u2", "email": "member2@example.com", "role": "standard-user", "created_time": "2026-04-16T08:05:00"},
+                    ],
+                }
+
+            async def stub_invites(*args, **kwargs):
+                return {
+                    "success": True,
+                    "total": 3,
+                    "items": [
+                        {"email_address": "joined@example.com", "role": "standard-user", "created_time": "2026-04-16T08:10:00", "status": "pending"},
+                        {"email_address": "pending@example.com", "role": "standard-user", "created_time": "2026-04-16T08:15:00", "status": "pending"},
+                        {"email_address": "accepted@example.com", "role": "standard-user", "created_time": "2026-04-16T08:20:00", "status": "accepted"},
+                    ],
+                }
+
+            with patch.object(team_service, "ensure_access_token", new=self._return_token), \
+                 patch.object(team_service.chatgpt_service, "get_members", new=stub_members), \
+                 patch.object(team_service.chatgpt_service, "get_invites", new=stub_invites):
+                result = await team_service.get_team_members(67, session)
+
+            self.assertTrue(result["success"])
+            self.assertEqual(result["total"], 3)
+            emails = [item["email"] for item in result["members"]]
+            self.assertEqual(emails.count("joined@example.com"), 1)
+            self.assertIn("pending@example.com", emails)
+            self.assertNotIn("accepted@example.com", emails)
+
+    async def test_generate_welfare_common_code_binds_selected_team(self):
+        async with self.session_factory() as session:
+            welfare_team = Team(
+                id=68,
+                email="welfare-owner-68@example.com",
+                access_token_encrypted="token-68",
+                account_id="acct-68",
+                team_name="Bound Welfare Team",
+                current_members=3,
+                max_members=5,
+                status="active",
+                pool_type="welfare",
+            )
+            other_team = Team(
+                id=69,
+                email="welfare-owner-69@example.com",
+                access_token_encrypted="token-69",
+                account_id="acct-69",
+                team_name="Other Welfare Team",
+                current_members=0,
+                max_members=10,
+                status="active",
+                pool_type="welfare",
+            )
+            session.add_all([welfare_team, other_team])
+            await session.commit()
+
+            response = await generate_welfare_common_code(
+                payload=WelfareCodeGenerateRequest(team_id=68),
+                db=session,
+                current_user={"username": "admin"},
+            )
+
+            self.assertIsInstance(response, JSONResponse)
+            payload = json.loads(response.body.decode("utf-8"))
+            self.assertTrue(payload["success"])
+            self.assertEqual(payload["team_id"], 68)
+            self.assertEqual(payload["limit"], 2)
+            self.assertEqual(payload["remaining"], 2)
+
+            stored_team_id = await settings_service.get_setting(session, "welfare_common_code_team_id", "")
+            self.assertEqual(stored_team_id, "68")
+
+            code_value = payload["code"]
+            usage = await RedemptionService().get_virtual_welfare_code_usage(session, welfare_code=code_value)
+            self.assertEqual(usage["team_id"], 68)
+            self.assertEqual(usage["configured_limit"], 2)
+            self.assertEqual(usage["remaining_count"], 2)
+            self.assertEqual(usage["usable_capacity"], 2)
+
+    async def test_generate_welfare_common_code_returns_error_when_settings_write_fails(self):
+        async with self.session_factory() as session:
+            welfare_team = Team(
+                id=75,
+                email="welfare-owner-75@example.com",
+                access_token_encrypted="token-75",
+                account_id="acct-75",
+                team_name="Settings Failure Team",
+                current_members=1,
+                max_members=4,
+                status="active",
+                pool_type="welfare",
+            )
+            session.add(welfare_team)
+            await session.commit()
+
+            with patch("app.routes.admin.settings_service.update_settings", return_value=False):
+                response = await generate_welfare_common_code(
+                    payload=WelfareCodeGenerateRequest(team_id=75),
+                    db=session,
+                    current_user={"username": "admin"},
+                )
+
+            self.assertIsInstance(response, JSONResponse)
+            self.assertEqual(response.status_code, 500)
+            payload = json.loads(response.body.decode("utf-8"))
+            self.assertFalse(payload["success"])
+            self.assertIn("写入福利通用兑换码配置失败", payload["error"])
+
+    async def test_verify_virtual_welfare_code_returns_only_bound_team(self):
+        async with self.session_factory() as session:
+            bound_team = Team(
+                id=70,
+                email="welfare-owner-70@example.com",
+                access_token_encrypted="token-70",
+                account_id="acct-70",
+                team_name="Bound Team",
+                current_members=1,
+                max_members=4,
+                status="active",
+                pool_type="welfare",
+            )
+            other_team = Team(
+                id=71,
+                email="welfare-owner-71@example.com",
+                access_token_encrypted="token-71",
+                account_id="acct-71",
+                team_name="Other Team",
+                current_members=0,
+                max_members=6,
+                status="active",
+                pool_type="welfare",
+            )
+            session.add_all([bound_team, other_team])
+            await session.commit()
+
+            service = RedemptionService()
+            await service.ensure_virtual_welfare_shadow_code(session, "WELF-BOUND-001")
+            settings_service.clear_cache()
+            await settings_service.update_setting(session, "welfare_common_code", "WELF-BOUND-001")
+            await settings_service.update_setting(session, "welfare_common_code_limit", "3")
+            await settings_service.update_setting(session, "welfare_common_code_used_count", "0")
+            await settings_service.update_setting(session, "welfare_common_code_team_id", "70")
+            await session.commit()
+
+            flow_service = RedeemFlowService()
+            result = await flow_service.verify_code_and_get_teams("WELF-BOUND-001", session)
+
+            self.assertTrue(result["success"])
+            self.assertTrue(result["valid"])
+            self.assertEqual(len(result["teams"]), 1)
+            self.assertEqual(result["teams"][0]["id"], 70)
+
+    async def test_redeem_virtual_welfare_code_rejects_unbound_selected_team(self):
+        async with self.session_factory() as session:
+            bound_team = Team(
+                id=72,
+                email="welfare-owner-72@example.com",
+                access_token_encrypted="token-72",
+                account_id="acct-72",
+                team_name="Bound Redeem Team",
+                current_members=0,
+                max_members=3,
+                status="active",
+                pool_type="welfare",
+            )
+            other_team = Team(
+                id=73,
+                email="welfare-owner-73@example.com",
+                access_token_encrypted="token-73",
+                account_id="acct-73",
+                team_name="Other Redeem Team",
+                current_members=0,
+                max_members=3,
+                status="active",
+                pool_type="welfare",
+            )
+            session.add_all([bound_team, other_team])
+            await session.commit()
+
+            redemption_service = RedemptionService()
+            await redemption_service.ensure_virtual_welfare_shadow_code(session, "WELF-BOUND-REDEEM")
+            settings_service.clear_cache()
+            await settings_service.update_setting(session, "welfare_common_code", "WELF-BOUND-REDEEM")
+            await settings_service.update_setting(session, "welfare_common_code_limit", "3")
+            await settings_service.update_setting(session, "welfare_common_code_used_count", "0")
+            await settings_service.update_setting(session, "welfare_common_code_team_id", "72")
+            await session.commit()
+
+            service = RedeemFlowService()
+            service.chatgpt_service = StubChatGPTService({})
+
+            with patch("app.services.redeem_flow.asyncio.create_task", side_effect=self._close_coro):
+                result = await service.redeem_and_join_team(
+                    email="user@example.com",
+                    code="WELF-BOUND-REDEEM",
+                    team_id=73,
+                    db_session=session,
+                )
+
+            self.assertFalse(result["success"])
+            self.assertIn("仅可兑换到其绑定的 Team", result["error"])
+
+    async def test_validate_virtual_welfare_code_fails_when_team_binding_points_to_deleted_team(self):
+        async with self.session_factory() as session:
+            team = Team(
+                id=74,
+                email="welfare-owner-74@example.com",
+                access_token_encrypted="token-74",
+                account_id="acct-74",
+                team_name="Deleted Binding Team",
+                current_members=0,
+                max_members=4,
+                status="active",
+                pool_type="welfare",
+            )
+            session.add(team)
+            await session.commit()
+
+            service = RedemptionService()
+            await service.ensure_virtual_welfare_shadow_code(session, "WELF-DELETED-BIND")
+            settings_service.clear_cache()
+            await settings_service.update_setting(session, "welfare_common_code", "WELF-DELETED-BIND")
+            await settings_service.update_setting(session, "welfare_common_code_limit", "4")
+            await settings_service.update_setting(session, "welfare_common_code_used_count", "0")
+            await settings_service.update_setting(session, "welfare_common_code_team_id", "74")
+            await session.delete(team)
+            await session.commit()
+
+            result = await service.validate_code("WELF-DELETED-BIND", session)
+            self.assertTrue(result["success"])
+            self.assertFalse(result["valid"])
+            self.assertIn("未绑定有效 Team", result["reason"])


### PR DESCRIPTION
Fix welfare Team member counts so they fall after member removal, filter stale invite counts, and generate the shared welfare code from an explicitly selected welfare Team instead of the whole pool.