### PR TITLE
fix(web): refresh cached admin script

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -463,7 +463,7 @@ eyJ..."></textarea>
     <div id="toast" class="toast"></div>
 
     <script>window.SYSTEM_UI_THEME = {{ ui_theme|default("ocean")|tojson }};</script>
-    <script src="/static/js/main.js?v=20260321-toast-modal-layer-fix-1"></script>
+    <script src="/static/js/main.js?v=20260416-welfare-team-code-bind-fix-1"></script>
     <script>
         lucide.createIcons();
     </script>


### PR DESCRIPTION
Bump the admin main.js asset version so browsers load the updated welfare code generation flow instead of a stale cached script.