### PR TITLE
perf(admin): parallelize batch team refresh

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -2,6 +2,7 @@
 管理员路由
 处理管理员面板的所有页面和操作
 """
+import asyncio
 import json
 import logging
 import re
@@ -1268,54 +1269,86 @@ async def batch_refresh_teams(
         async def progress_generator():
             success_count = 0
             failed_count = 0
+            completed_count = 0
             total = len(team_ids)
+            concurrency = min(3, total) if total > 0 else 1
 
             yield json.dumps({
                 "type": "start",
                 "total": total,
                 "success_count": success_count,
                 "failed_count": failed_count,
+                "completed_count": completed_count,
+                "concurrency": concurrency,
             }, ensure_ascii=False) + "\n"
 
-            async with AsyncSessionLocal() as db_session:
-                for index, team_id in enumerate(team_ids, start=1):
-                    item_success = False
-                    item_error = None
-                    item_message = None
+            async def refresh_single_team(team_id: int) -> Dict[str, object]:
+                item_success = False
+                item_error = None
+                item_message = None
 
-                    try:
+                try:
+                    async with AsyncSessionLocal() as db_session:
                         result = await team_service.sync_team_info(team_id, db_session, force_refresh=True)
-                        item_success = bool(result.get("success"))
-                        item_message = result.get("message")
-                        item_error = result.get("error")
-                    except Exception as ex:
-                        logger.error(f"批量刷新 Team {team_id} 时出错: {ex}")
-                        item_error = str(ex)
+                    item_success = bool(result.get("success"))
+                    item_message = result.get("message")
+                    item_error = result.get("error")
+                except Exception as ex:
+                    logger.error(f"批量刷新 Team {team_id} 时出错: {ex}")
+                    item_error = str(ex)
 
-                    if item_success:
-                        success_count += 1
-                    else:
-                        failed_count += 1
+                return {
+                    "team_id": team_id,
+                    "success": item_success,
+                    "message": item_message,
+                    "error": item_error,
+                }
 
-                    yield json.dumps({
-                        "type": "progress",
-                        "current": index,
-                        "total": total,
-                        "success_count": success_count,
-                        "failed_count": failed_count,
-                        "team_id": team_id,
-                        "last_result": {
-                            "success": item_success,
-                            "message": item_message,
-                            "error": item_error,
-                        }
-                    }, ensure_ascii=False) + "\n"
+            for start_index in range(0, total, concurrency):
+                team_batch = team_ids[start_index:start_index + concurrency]
+                pending_tasks = {
+                    asyncio.create_task(refresh_single_team(team_id))
+                    for team_id in team_batch
+                }
+
+                while pending_tasks:
+                    done_tasks, pending_tasks = await asyncio.wait(
+                        pending_tasks,
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+
+                    for done_task in done_tasks:
+                        item = await done_task
+                        completed_count += 1
+                        item_success = bool(item["success"])
+                        if item_success:
+                            success_count += 1
+                        else:
+                            failed_count += 1
+
+                        yield json.dumps({
+                            "type": "progress",
+                            "current": completed_count,
+                            "completed_count": completed_count,
+                            "total": total,
+                            "success_count": success_count,
+                            "failed_count": failed_count,
+                            "team_id": item["team_id"],
+                            "concurrency": concurrency,
+                            "last_result": {
+                                "success": item_success,
+                                "message": item["message"],
+                                "error": item["error"],
+                            }
+                        }, ensure_ascii=False) + "\n"
 
             yield json.dumps({
                 "type": "finish",
                 "total": total,
                 "success_count": success_count,
                 "failed_count": failed_count,
+                "completed_count": completed_count,
+                "concurrency": concurrency,
                 "message": f"批量刷新完成: 成功 {success_count}, 失败 {failed_count}"
             }, ensure_ascii=False) + "\n"
 

--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -1930,6 +1930,21 @@
         }
     }
 
+    function formatBatchRefreshStatusText({
+        actionLabel,
+        current,
+        total,
+        success,
+        failed,
+        waiting = false,
+    }) {
+        let text = `${actionLabel}，已完成：<strong>${current}</strong>/<strong>${total}</strong>，成功 ${success}，失败 ${failed}。`;
+        if (waiting) {
+            text += ' 请稍候…';
+        }
+        return text;
+    }
+
     function updateBatchRefreshProgress({ current, total, success, failed, text }) {
         const barNode = document.getElementById('batchRefreshProgressBar');
         const percentNode = document.getElementById('batchRefreshProgressPercent');
@@ -2028,6 +2043,7 @@
         emptyMessage,
         confirmMessage,
         progressVerb,
+        progressActionLabel,
         successVerb,
         failedMessage,
         interruptedMessage,
@@ -2045,12 +2061,21 @@
         showBatchRefreshProgress();
         setBatchRefreshProgressTitle(panelTitle);
         setBatchActionButtonsDisabled(true);
+        const actionLabel = progressActionLabel || progressVerb;
+
         updateBatchRefreshProgress({
             current: 0,
             total: totalCount,
             success: 0,
             failed: 0,
-            text: `${progressVerb}，当前进度：<strong>0</strong>/<strong>${totalCount}</strong>，请稍候…`
+            text: formatBatchRefreshStatusText({
+                actionLabel,
+                current: 0,
+                total: totalCount,
+                success: 0,
+                failed: 0,
+                waiting: true,
+            })
         });
         showToast(startMessage, 'info');
 
@@ -2094,19 +2119,32 @@
 
                     if (data.type === 'start') {
                         updateBatchRefreshProgress({
-                            current: 0,
+                            current: data.completed_count || 0,
                             total: data.total || totalCount,
                             success: data.success_count || 0,
                             failed: data.failed_count || 0,
-                            text: `${progressVerb}，当前进度：<strong>0</strong>/<strong>${data.total || totalCount}</strong>，请稍候…`
+                            text: formatBatchRefreshStatusText({
+                                actionLabel,
+                                current: data.completed_count || 0,
+                                total: data.total || totalCount,
+                                success: data.success_count || 0,
+                                failed: data.failed_count || 0,
+                                waiting: true,
+                            })
                         });
                     } else if (data.type === 'progress') {
                         updateBatchRefreshProgress({
-                            current: data.current || 0,
+                            current: data.completed_count || data.current || 0,
                             total: data.total || totalCount,
                             success: data.success_count || 0,
                             failed: data.failed_count || 0,
-                            text: `${progressVerb}，当前进度：<strong>${data.current || 0}</strong>/<strong>${data.total || totalCount}</strong>，成功 ${data.success_count || 0}，失败 ${data.failed_count || 0}。`
+                            text: formatBatchRefreshStatusText({
+                                actionLabel,
+                                current: data.completed_count || data.current || 0,
+                                total: data.total || totalCount,
+                                success: data.success_count || 0,
+                                failed: data.failed_count || 0,
+                            })
                         });
                     } else if (data.type === 'finish') {
                         finalResult = data;
@@ -2157,6 +2195,7 @@
             emptyMessage: '请选择要刷新的 Team',
             confirmMessage: `确定要批量刷新选中的 ${selectedIds.length} 个 Team 吗？`,
             progressVerb: '正在刷新中',
+            progressActionLabel: '正在批量刷新 Team',
             successVerb: '批量刷新完成',
             failedMessage: '批量刷新失败',
             interruptedMessage: '批量刷新连接已中断，未收到完成信号，请检查网络或稍后重试',
@@ -2173,6 +2212,7 @@
             emptyMessage: '当前池没有可检测的 Team',
             confirmMessage: `确定要检测${currentPoolLabel}全部 ${totalTeamsInCurrentPool} 个 Team 的存活情况吗？\n\n此操作会同步 Team 信息并更新状态，不受当前搜索、筛选和分页影响。`,
             progressVerb: '正在检测 Team 存活',
+            progressActionLabel: '正在检测 Team 存活',
             successVerb: '检测完成',
             failedMessage: '检测 Team 存活失败',
             interruptedMessage: '检测 Team 存活连接已中断，未收到完成信号，请检查网络或稍后重试',


### PR DESCRIPTION
Run admin batch refreshes up to three teams at a time with isolated DB sessions so pool-wide live checks finish faster. Keep the progress panel focused on completion and success or failure counts while updating as each team finishes.