### PR TITLE
fix(admin): keep code bulk actions visible

### DIFF
--- a/app/templates/admin/codes/index.html
+++ b/app/templates/admin/codes/index.html
@@ -536,16 +536,23 @@
     }
 
     #bulkActionBar.bulk-action-bar.viewport-floating {
-        position: static;
-        inset: auto;
-        transform: none;
-        width: 100%;
-        max-width: 100%;
+        position: fixed;
+        left: 50%;
+        bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
+        transform: translateX(-50%);
+        width: min(calc(100vw - 2rem), 960px);
+        max-width: calc(100vw - 2rem);
+        margin-top: 0;
         padding: 0.85rem 1rem;
-        box-shadow: var(--shadow-sm);
-        border-radius: 16px;
-        backdrop-filter: none;
+        box-shadow: 0 18px 40px rgba(15, 23, 42, 0.16);
+        border-radius: 18px;
+        backdrop-filter: blur(14px);
         animation: none;
+        z-index: 900;
+    }
+
+    body.bulk-action-visible .codes-workspace-page {
+        padding-bottom: calc(var(--bulk-action-bar-height, 0px) + 1.5rem + env(safe-area-inset-bottom, 0px));
     }
 
     .bulk-info {
@@ -605,6 +612,12 @@
         }
 
         #bulkActionBar.bulk-action-bar.viewport-floating {
+            left: 1rem;
+            right: 1rem;
+            bottom: calc(0.75rem + env(safe-area-inset-bottom, 0px));
+            transform: none;
+            width: auto;
+            max-width: none;
             padding: 0.75rem;
             gap: 0.75rem;
             flex-direction: column;
@@ -798,9 +811,15 @@
         if (count > 0) {
             actionBar.style.display = 'flex';
             actionBar.classList.add('viewport-floating');
+            document.body.classList.add('bulk-action-visible');
+            requestAnimationFrame(() => {
+                document.documentElement.style.setProperty('--bulk-action-bar-height', `${actionBar.offsetHeight}px`);
+            });
         } else {
             actionBar.style.display = 'none';
             actionBar.classList.remove('viewport-floating');
+            document.body.classList.remove('bulk-action-visible');
+            document.documentElement.style.removeProperty('--bulk-action-bar-height');
         }
     }
 


### PR DESCRIPTION
Keep the codes batch action bar pinned to the viewport after selection so admins can reach bulk edit and delete actions without scrolling to the end of long tables.