### PR TITLE
feat(warranty): add expired warranty auto-kick automation

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -49,6 +49,10 @@ MIN_PERIODIC_TEAM_SYNC_INTERVAL_HOURS = 1
 MAX_PERIODIC_TEAM_SYNC_INTERVAL_HOURS = 24 * 7
 MIN_PERIODIC_TEAM_SYNC_DAYS = 1
 MAX_PERIODIC_TEAM_SYNC_DAYS = 30
+DEFAULT_WARRANTY_AUTO_KICK_ENABLED = False
+DEFAULT_WARRANTY_AUTO_KICK_INTERVAL_HOURS = 12
+MIN_WARRANTY_AUTO_KICK_INTERVAL_HOURS = 1
+MAX_WARRANTY_AUTO_KICK_INTERVAL_HOURS = 24 * 7
 
 
 def _safe_int(value, default):
@@ -74,6 +78,10 @@ def normalize_periodic_team_sync_interval_hours(interval_hours: int) -> int:
 
 def normalize_periodic_team_sync_days(refresh_interval_days: int) -> int:
     return max(MIN_PERIODIC_TEAM_SYNC_DAYS, min(MAX_PERIODIC_TEAM_SYNC_DAYS, refresh_interval_days))
+
+
+def normalize_warranty_auto_kick_interval_hours(interval_hours: int) -> int:
+    return max(MIN_WARRANTY_AUTO_KICK_INTERVAL_HOURS, min(MAX_WARRANTY_AUTO_KICK_INTERVAL_HOURS, interval_hours))
 
 
 def configure_periodic_team_sync_job(enabled: bool, interval_hours: int) -> int:
@@ -173,6 +181,58 @@ async def configure_proactive_refresh_job_from_settings() -> int:
     return configure_proactive_refresh_job(interval)
 
 
+def configure_warranty_auto_kick_job(enabled: bool, interval_hours: int) -> int:
+    """配置（或重配置）质保过期自动踢人任务。"""
+    normalized_interval = normalize_warranty_auto_kick_interval_hours(interval_hours)
+    existing_job = scheduler.get_job("warranty_auto_kick")
+
+    if not enabled:
+        if existing_job:
+            scheduler.remove_job("warranty_auto_kick")
+        return normalized_interval
+
+    trigger = IntervalTrigger(hours=normalized_interval)
+    if existing_job:
+        scheduler.reschedule_job("warranty_auto_kick", trigger=trigger)
+    else:
+        scheduler.add_job(
+            scheduled_warranty_auto_kick,
+            trigger=trigger,
+            id="warranty_auto_kick",
+            replace_existing=True,
+            max_instances=1,
+        )
+
+    if not scheduler.running:
+        scheduler.start()
+
+    return normalized_interval
+
+
+async def configure_warranty_auto_kick_job_from_settings() -> tuple[bool, int]:
+    """从系统设置读取质保过期自动踢人配置并应用到定时任务。"""
+    from app.services.settings import settings_service
+
+    async with AsyncSessionLocal() as session:
+        enabled_raw = await settings_service.get_setting(
+            session,
+            "warranty_auto_kick_enabled",
+            str(DEFAULT_WARRANTY_AUTO_KICK_ENABLED).lower(),
+        )
+        interval_raw = await settings_service.get_setting(
+            session,
+            "warranty_auto_kick_interval_hours",
+            str(DEFAULT_WARRANTY_AUTO_KICK_INTERVAL_HOURS),
+        )
+
+    enabled = str(enabled_raw).lower() in {"1", "true", "yes", "on"}
+    interval_hours = normalize_warranty_auto_kick_interval_hours(
+        _safe_int(interval_raw, DEFAULT_WARRANTY_AUTO_KICK_INTERVAL_HOURS)
+    )
+    applied_interval = configure_warranty_auto_kick_job(enabled, interval_hours)
+    return enabled, applied_interval
+
+
 async def scheduled_proactive_refresh():
     """定时执行 Team Token 预刷新（间隔可配置）。"""
     from app.services.settings import settings_service
@@ -221,6 +281,38 @@ async def scheduled_periodic_team_status_sync():
             )
     except Exception as e:
         logger.error(f"Team 周期状态同步任务执行失败: {e}")
+
+
+async def scheduled_warranty_auto_kick():
+    """定时扫描已过保的质保兑换码并自动踢人、销毁兑换码。"""
+    from app.services.warranty import warranty_service
+
+    try:
+        async with AsyncSessionLocal() as session:
+            stats = await warranty_service.run_warranty_auto_kick(session)
+            if stats.get("success"):
+                logger.info(
+                    "质保自动踢人完成: scanned=%s expired=%s processed=%s destroyed=%s skipped=%s failed=%s",
+                    stats["scanned"],
+                    stats["expired_candidates"],
+                    stats["processed"],
+                    stats["destroyed"],
+                    stats["skipped"],
+                    stats["failed"],
+                )
+            else:
+                logger.warning(
+                    "质保自动踢人任务部分失败: scanned=%s expired=%s processed=%s destroyed=%s skipped=%s failed=%s error=%s",
+                    stats.get("scanned", 0),
+                    stats.get("expired_candidates", 0),
+                    stats.get("processed", 0),
+                    stats.get("destroyed", 0),
+                    stats.get("skipped", 0),
+                    stats.get("failed", 0),
+                    stats.get("error"),
+                )
+    except Exception as e:
+        logger.error(f"质保自动踢人任务执行失败: {e}")
 
 
 @asynccontextmanager
@@ -277,6 +369,15 @@ async def lifespan(app: FastAPI):
             )
         else:
             logger.info("Team 周期状态同步任务已禁用")
+
+        warranty_auto_kick_enabled, warranty_auto_kick_interval = await configure_warranty_auto_kick_job_from_settings()
+        if warranty_auto_kick_enabled:
+            logger.info(
+                "定时任务已启动: 每 %s 小时检查一次质保过期自动踢人",
+                warranty_auto_kick_interval,
+            )
+        else:
+            logger.info("质保过期自动踢人任务已禁用")
 
         logger.info("数据库初始化完成")
     except Exception as e:

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -2194,6 +2194,8 @@ async def settings_page(
                 "periodic_team_sync_enabled": await settings_service.get_setting(db, "periodic_team_sync_enabled", "true"),
                 "periodic_team_sync_interval_hours": await settings_service.get_setting(db, "periodic_team_sync_interval_hours", "12"),
                 "periodic_team_sync_days": await settings_service.get_setting(db, "periodic_team_sync_days", "7"),
+                "warranty_auto_kick_enabled": await settings_service.get_setting(db, "warranty_auto_kick_enabled", "false"),
+                "warranty_auto_kick_interval_hours": await settings_service.get_setting(db, "warranty_auto_kick_interval_hours", "12"),
                 "default_team_max_members": await settings_service.get_setting(db, "default_team_max_members", "6"),
                 "cliproxyapi_base_url": await settings_service.get_setting(db, "cliproxyapi_base_url", ""),
                 "cliproxyapi_api_key": await settings_service.get_setting(db, "cliproxyapi_api_key", ""),
@@ -2251,6 +2253,12 @@ class TeamAutoRefreshSettingsRequest(BaseModel):
     enabled: bool = Field(True, description="是否启用 Team 周期状态自动刷新")
     interval_hours: int = Field(12, ge=1, le=168, description="检查间隔（小时）")
     refresh_interval_days: int = Field(7, ge=1, le=30, description="同步周期（天）")
+
+
+class WarrantyAutoKickSettingsRequest(BaseModel):
+    """质保过期自动踢人设置请求"""
+    enabled: bool = Field(False, description="是否启用质保过期自动踢人")
+    interval_hours: int = Field(12, ge=1, le=168, description="检查间隔（小时）")
 
 
 class WarrantyExpirationSettingsRequest(BaseModel):
@@ -2681,6 +2689,61 @@ async def update_warranty_settings(
         )
     except Exception as e:
         logger.exception("更新质保设置失败")
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content={"success": False, "error": "更新失败，请稍后重试"}
+        )
+
+
+@router.post("/settings/warranty-auto-kick")
+async def update_warranty_auto_kick_settings(
+    auto_kick_data: WarrantyAutoKickSettingsRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: dict = Depends(require_admin)
+):
+    """更新质保过期自动踢人设置。"""
+    try:
+        from app.main import configure_warranty_auto_kick_job
+
+        logger.info(
+            "管理员更新质保过期自动踢人配置: enabled=%s, interval_hours=%s",
+            auto_kick_data.enabled,
+            auto_kick_data.interval_hours,
+        )
+
+        success = await settings_service.update_settings(
+            db,
+            {
+                "warranty_auto_kick_enabled": str(auto_kick_data.enabled).lower(),
+                "warranty_auto_kick_interval_hours": str(auto_kick_data.interval_hours),
+            }
+        )
+        if not success:
+            return JSONResponse(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                content={"success": False, "error": "保存失败"}
+            )
+
+        applied_interval = configure_warranty_auto_kick_job(
+            auto_kick_data.enabled,
+            auto_kick_data.interval_hours,
+        )
+
+        message = (
+            f"自动踢人配置已保存（每 {applied_interval} 小时检查一次）"
+            if auto_kick_data.enabled
+            else "自动踢人已关闭"
+        )
+        return JSONResponse(
+            content={
+                "success": True,
+                "message": message,
+                "enabled": auto_kick_data.enabled,
+                "interval_hours": applied_interval,
+            }
+        )
+    except Exception:
+        logger.exception("更新质保过期自动踢人设置失败")
         return JSONResponse(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             content={"success": False, "error": "更新失败，请稍后重试"}

--- a/app/services/redemption.py
+++ b/app/services/redemption.py
@@ -259,6 +259,96 @@ class RedemptionService:
                 "error": "扫描无效兑换码失败，请稍后重试"
             }
 
+    async def _destroy_codes_with_records(
+        self,
+        codes: List[str],
+        db_session: AsyncSession,
+    ) -> Dict[str, Any]:
+        """物理删除兑换码及其全部兑换记录。"""
+        normalized_codes: List[str] = []
+        seen_codes: set[str] = set()
+        for raw_code in codes or []:
+            code = str(raw_code or "").strip()
+            if not code or code in seen_codes:
+                continue
+            seen_codes.add(code)
+            normalized_codes.append(code)
+
+        if not normalized_codes:
+            return {
+                "success": False,
+                "deleted_codes": [],
+                "deleted_records": 0,
+                "error": "请选择需要删除的兑换码",
+            }
+
+        record_count_result = await db_session.execute(
+            select(func.count(RedemptionRecord.id)).where(RedemptionRecord.code.in_(normalized_codes))
+        )
+        deleted_records = int(record_count_result.scalar() or 0)
+
+        await db_session.execute(
+            delete(RedemptionRecord).where(RedemptionRecord.code.in_(normalized_codes))
+        )
+        await db_session.execute(
+            delete(RedemptionCode).where(RedemptionCode.code.in_(normalized_codes))
+        )
+        await db_session.commit()
+
+        return {
+            "success": True,
+            "deleted_codes": normalized_codes,
+            "deleted_records": deleted_records,
+            "error": None,
+        }
+
+    async def destroy_code_with_records(
+        self,
+        code: str,
+        db_session: AsyncSession,
+    ) -> Dict[str, Any]:
+        """销毁单个兑换码及其全部兑换记录。"""
+        try:
+            normalized_code = str(code or "").strip()
+            if not normalized_code:
+                return {"success": False, "error": "兑换码不能为空"}
+
+            existing_result = await db_session.execute(
+                select(RedemptionCode).where(RedemptionCode.code == normalized_code)
+            )
+            redemption_code = existing_result.scalar_one_or_none()
+            if not redemption_code:
+                return {
+                    "success": False,
+                    "message": None,
+                    "error": f"兑换码 {normalized_code} 不存在",
+                }
+
+            destroy_result = await self._destroy_codes_with_records([normalized_code], db_session)
+            if not destroy_result["success"]:
+                return {
+                    "success": False,
+                    "message": None,
+                    "error": destroy_result.get("error") or "销毁兑换码失败",
+                }
+
+            logger.info(
+                "销毁兑换码成功: %s, 删除记录数: %s",
+                normalized_code,
+                destroy_result["deleted_records"],
+            )
+            return {
+                "success": True,
+                "message": f"兑换码 {normalized_code} 已销毁",
+                "deleted_codes": destroy_result["deleted_codes"],
+                "deleted_records": destroy_result["deleted_records"],
+                "error": None,
+            }
+        except Exception:
+            await db_session.rollback()
+            logger.exception("销毁兑换码失败")
+            return {"success": False, "message": None, "error": "销毁兑换码失败，请稍后重试"}
+
     async def cleanup_invalid_codes(
         self,
         codes: List[str],
@@ -281,13 +371,9 @@ class RedemptionService:
             if not requested_codes:
                 return {"success": False, "error": "所选兑换码不满足无效清理条件，已拒绝删除"}
 
-            await db_session.execute(
-                delete(RedemptionRecord).where(RedemptionRecord.code.in_(requested_codes))
-            )
-            await db_session.execute(
-                delete(RedemptionCode).where(RedemptionCode.code.in_(requested_codes))
-            )
-            await db_session.commit()
+            destroy_result = await self._destroy_codes_with_records(requested_codes, db_session)
+            if not destroy_result["success"]:
+                return {"success": False, "error": destroy_result.get("error") or "批量清理失败"}
 
             message = f"已清理 {len(requested_codes)} 个无效兑换码"
             if rejected_codes:
@@ -296,7 +382,8 @@ class RedemptionService:
             return {
                 "success": True,
                 "message": message,
-                "deleted_codes": requested_codes,
+                "deleted_codes": destroy_result["deleted_codes"],
+                "deleted_records": destroy_result["deleted_records"],
                 "skipped_codes": rejected_codes,
                 "error": None
             }

--- a/app/services/warranty.py
+++ b/app/services/warranty.py
@@ -77,13 +77,14 @@ class WarrantyService:
         db_session: AsyncSession,
         redemption_code: RedemptionCode,
         reference_record: Optional[RedemptionRecord] = None,
-        expiration_mode: Optional[str] = None
+        expiration_mode: Optional[str] = None,
+        force_recompute: bool = False,
     ) -> Optional[datetime]:
         """获取质保截止时间，必要时按当前模式动态回退计算。"""
         if not redemption_code.has_warranty:
             return None
 
-        if redemption_code.warranty_expires_at:
+        if redemption_code.warranty_expires_at and not force_recompute:
             return redemption_code.warranty_expires_at
 
         start_time = await self._get_warranty_start_time(
@@ -377,6 +378,239 @@ class WarrantyService:
                 "success": False,
                 "error": f"检查质保状态失败: {str(e)}"
             }
+
+    async def scan_expired_warranty_codes(
+        self,
+        db_session: AsyncSession,
+        limit: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """扫描按当前质保模式已过保、且仍绑定 Team/邮箱的质保码。"""
+        try:
+            expiration_mode = await settings_service.get_warranty_expiration_mode(db_session)
+            stmt = select(RedemptionCode).where(
+                RedemptionCode.has_warranty.is_(True),
+                RedemptionCode.used_by_email.is_not(None),
+                RedemptionCode.used_team_id.is_not(None),
+                RedemptionCode.used_at.is_not(None),
+            ).order_by(RedemptionCode.used_at.asc(), RedemptionCode.id.asc())
+            if limit and limit > 0:
+                stmt = stmt.limit(limit)
+
+            result = await db_session.execute(stmt)
+            codes = result.scalars().all()
+
+            now = get_now()
+            candidates: List[Dict[str, Any]] = []
+            for redemption_code in codes:
+                expiry_date = await self._resolve_warranty_expiry_date(
+                    db_session,
+                    redemption_code,
+                    expiration_mode=expiration_mode,
+                    force_recompute=True,
+                )
+                if not expiry_date or expiry_date >= now:
+                    continue
+
+                normalized_email = self.team_service._normalize_member_email(redemption_code.used_by_email)
+                if not normalized_email:
+                    continue
+
+                record_count_result = await db_session.execute(
+                    select(func.count(RedemptionRecord.id)).where(RedemptionRecord.code == redemption_code.code)
+                )
+                record_count = int(record_count_result.scalar() or 0)
+                candidates.append({
+                    "code": redemption_code.code,
+                    "email": normalized_email,
+                    "team_id": redemption_code.used_team_id,
+                    "used_at": redemption_code.used_at.isoformat() if redemption_code.used_at else None,
+                    "warranty_expires_at": expiry_date.isoformat(),
+                    "record_count": record_count,
+                    "expiration_mode": expiration_mode,
+                })
+
+            return {
+                "success": True,
+                "codes": candidates,
+                "total": len(candidates),
+                "error": None,
+            }
+        except Exception as e:
+            logger.error(f"扫描过保质保码失败: {e}")
+            return {
+                "success": False,
+                "codes": [],
+                "total": 0,
+                "error": f"扫描过保质保码失败: {str(e)}",
+            }
+
+    async def kick_and_destroy_expired_warranty_code(
+        self,
+        db_session: AsyncSession,
+        code: str,
+    ) -> Dict[str, Any]:
+        """对单个已过保质保码执行踢人与销毁。"""
+        try:
+            normalized_code = str(code or "").strip()
+            if not normalized_code:
+                return {"success": False, "code": code, "error": "兑换码不能为空"}
+
+            result = await db_session.execute(
+                select(RedemptionCode).where(RedemptionCode.code == normalized_code)
+            )
+            redemption_code = result.scalar_one_or_none()
+            if not redemption_code:
+                return {
+                    "success": True,
+                    "code": normalized_code,
+                    "action": "already_destroyed",
+                    "message": "兑换码已不存在",
+                    "error": None,
+                }
+
+            if not redemption_code.has_warranty:
+                return {
+                    "success": False,
+                    "code": normalized_code,
+                    "error": "该兑换码不是质保码",
+                }
+
+            expiration_mode = await settings_service.get_warranty_expiration_mode(db_session)
+            expiry_date = await self._resolve_warranty_expiry_date(
+                db_session,
+                redemption_code,
+                expiration_mode=expiration_mode,
+                force_recompute=True,
+            )
+            if not expiry_date or expiry_date >= get_now():
+                return {
+                    "success": False,
+                    "code": normalized_code,
+                    "error": "质保尚未过期",
+                }
+
+            team_id = redemption_code.used_team_id
+            email = self.team_service._normalize_member_email(redemption_code.used_by_email)
+            if not team_id:
+                return {
+                    "success": False,
+                    "code": normalized_code,
+                    "error": "兑换码未绑定 Team，无法自动踢人",
+                }
+            if not email:
+                return {
+                    "success": False,
+                    "code": normalized_code,
+                    "error": "兑换码未绑定邮箱，无法自动踢人",
+                }
+
+            team_result = await db_session.execute(select(Team).where(Team.id == team_id))
+            team = team_result.scalar_one_or_none()
+            if not team:
+                return {
+                    "success": False,
+                    "code": normalized_code,
+                    "team_id": team_id,
+                    "email": email,
+                    "error": f"Team ID {team_id} 不存在",
+                }
+
+            removal_result = await self.team_service.remove_invite_or_member(team_id, email, db_session)
+            removal_message = str(removal_result.get("message") or "")
+            removal_error = str(removal_result.get("error") or "")
+            removal_success = bool(removal_result.get("success"))
+            already_absent = "成员已不存在" in removal_message
+
+            if not removal_success and not already_absent:
+                return {
+                    "success": False,
+                    "code": normalized_code,
+                    "team_id": team_id,
+                    "email": email,
+                    "error": removal_error or removal_message or "移除成员失败",
+                }
+
+            from app.services.redemption import redemption_service
+
+            destroy_result = await redemption_service.destroy_code_with_records(normalized_code, db_session)
+            if not destroy_result.get("success"):
+                return {
+                    "success": False,
+                    "code": normalized_code,
+                    "team_id": team_id,
+                    "email": email,
+                    "error": destroy_result.get("error") or "销毁兑换码失败",
+                }
+
+            return {
+                "success": True,
+                "code": normalized_code,
+                "team_id": team_id,
+                "email": email,
+                "action": "destroyed_after_absent" if already_absent else "kicked_and_destroyed",
+                "message": destroy_result.get("message") or "自动踢人并销毁兑换码成功",
+                "destroyed_records": destroy_result.get("deleted_records", 0),
+                "warranty_expires_at": expiry_date.isoformat(),
+            }
+        except Exception as e:
+            logger.exception("执行自动踢人并销毁兑换码失败")
+            return {
+                "success": False,
+                "code": code,
+                "error": f"执行自动踢人并销毁兑换码失败: {str(e)}",
+            }
+
+    async def run_warranty_auto_kick(
+        self,
+        db_session: AsyncSession,
+        limit: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """扫描并执行整轮质保过期自动踢人任务。"""
+        scan_result = await self.scan_expired_warranty_codes(db_session, limit=limit)
+        if not scan_result.get("success"):
+            return {
+                "success": False,
+                "scanned": 0,
+                "expired_candidates": 0,
+                "processed": 0,
+                "destroyed": 0,
+                "skipped": 0,
+                "failed": 0,
+                "error": scan_result.get("error") or "扫描失败",
+                "results": [],
+            }
+
+        candidates = scan_result.get("codes", [])
+        results: List[Dict[str, Any]] = []
+        processed = 0
+        destroyed = 0
+        skipped = 0
+        failed = 0
+
+        for candidate in candidates:
+            item_result = await self.kick_and_destroy_expired_warranty_code(db_session, candidate.get("code", ""))
+            results.append(item_result)
+            if item_result.get("success"):
+                processed += 1
+                destroyed += 1
+                continue
+
+            if item_result.get("error") == "质保尚未过期":
+                skipped += 1
+            else:
+                failed += 1
+
+        return {
+            "success": failed == 0,
+            "scanned": scan_result.get("total", 0),
+            "expired_candidates": len(candidates),
+            "processed": processed,
+            "destroyed": destroyed,
+            "skipped": skipped,
+            "failed": failed,
+            "error": None if failed == 0 else "部分过保质保码处理失败",
+            "results": results,
+        }
 
     async def validate_warranty_reuse(
         self,

--- a/app/templates/admin/settings/index.html
+++ b/app/templates/admin/settings/index.html
@@ -31,6 +31,7 @@
             <div class="settings-nav-group-title">自动化</div>
             <a href="#settings-refresh" class="settings-nav-pill settings-nav-link" data-target="settings-refresh">Token 预刷新</a>
             <a href="#settings-team-auto-refresh" class="settings-nav-pill settings-nav-link" data-target="settings-team-auto-refresh">Team 自动刷新</a>
+            <a href="#settings-warranty-auto-kick" class="settings-nav-pill settings-nav-link" data-target="settings-warranty-auto-kick">自动踢人</a>
         </div>
         <div class="settings-nav-group">
             <div class="settings-nav-group-title">业务规则</div>
@@ -190,6 +191,34 @@
         </div>
 
         <button type="submit" class="btn btn-primary">保存 Team 自动刷新配置</button>
+    </form>
+</div>
+
+
+<!-- 自动踢人配置 -->
+<div class="content-section settings-panel" id="settings-warranty-auto-kick">
+    <div class="section-header">
+        <h3>自动踢人</h3>
+    </div>
+
+    <form id="warrantyAutoKickForm" class="settings-form">
+        <div class="form-group">
+            <label class="checkbox-label">
+                <input type="checkbox" id="warrantyAutoKickEnabled" name="enabled" {% if (warranty_auto_kick_enabled or 'false')|lower in ['1','true','yes','on'] %}checked{% endif %}>
+                <span>启用质保过期自动踢人</span>
+            </label>
+            <p class="form-help">开启后，系统会按当前质保计算方式扫描已过保的质保兑换码；命中后自动从对应 Team 删除成员或撤回邀请，并销毁该兑换码及全部历史兑换记录。</p>
+        </div>
+
+        <div class="form-group">
+            <label for="warrantyAutoKickInterval">检查间隔 (小时)</label>
+            <input type="number" id="warrantyAutoKickInterval" name="interval_hours"
+                value="{{ warranty_auto_kick_interval_hours or '12' }}" min="1" max="168" class="form-control">
+            <p class="form-help">建议 6~24 小时。该任务会按当前后台选择的质保计算方式重新判断历史质保码是否过保。</p>
+        </div>
+
+        <p class="form-help">该操作不可恢复，请确认售后流程允许系统自动清退成员并销毁兑换码后再开启。</p>
+        <button type="submit" class="btn btn-primary">保存自动踢人配置</button>
     </form>
 </div>
 
@@ -566,6 +595,39 @@
 
             if (response.ok && data.success) {
                 showToast(data.message || 'Team 自动刷新配置已保存', 'success');
+            } else {
+                showToast(data.error || '保存失败', 'error');
+            }
+        } catch (error) {
+            showToast('网络错误', 'error');
+        }
+    });
+
+    // 自动踢人配置表单
+    document.getElementById('warrantyAutoKickForm').addEventListener('submit', async (e) => {
+        e.preventDefault();
+
+        const enabled = document.getElementById('warrantyAutoKickEnabled').checked;
+        const interval_hours = parseInt(document.getElementById('warrantyAutoKickInterval').value);
+
+        if (isNaN(interval_hours) || interval_hours < 1 || interval_hours > 168) {
+            showToast('检查间隔必须在 1~168 小时之间', 'error');
+            return;
+        }
+
+        try {
+            const response = await fetch('/admin/settings/warranty-auto-kick', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ enabled, interval_hours })
+            });
+
+            const data = await response.json();
+
+            if (response.ok && data.success) {
+                showToast(data.message || '自动踢人配置已保存', 'success');
             } else {
                 showToast(data.error || '保存失败', 'error');
             }

--- a/init_db.py
+++ b/init_db.py
@@ -64,6 +64,16 @@ async def create_default_settings():
                 value="first_use",
                 description="质保时长计算模式: first_use/refresh_on_redeem"
             ),
+            Setting(
+                key="warranty_auto_kick_enabled",
+                value="false",
+                description="是否启用质保过期自动踢人"
+            ),
+            Setting(
+                key="warranty_auto_kick_interval_hours",
+                value="12",
+                description="质保过期自动踢人检查间隔（小时）"
+            ),
         ]
 
         session.add_all(default_settings)

--- a/tests/test_redeem_flow.py
+++ b/tests/test_redeem_flow.py
@@ -148,6 +148,146 @@ class StubChatGPTService:
         return {"success": True, "data": {"account_invites": [{"email": email}]}}
 
 
+class WarrantyAutoKickTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        settings_service.clear_cache()
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        self.session_factory = async_sessionmaker(
+            self.engine,
+            class_=AsyncSession,
+            expire_on_commit=False,
+        )
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+            await conn.execute(__import__("sqlalchemy").text("PRAGMA foreign_keys=ON"))
+
+    async def asyncTearDown(self):
+        settings_service.clear_cache()
+        await self.engine.dispose()
+
+    async def test_scan_expired_warranty_codes_recomputes_history_using_current_mode(self):
+        async with self.session_factory() as session:
+            team = Team(
+                id=201,
+                email="owner@example.com",
+                access_token_encrypted="token-1",
+                account_id="acct-auto-kick",
+                team_name="Warranty Team",
+                current_members=1,
+                max_members=5,
+                status="active",
+                pool_type="normal",
+            )
+            session.add(team)
+            await session.commit()
+
+            code = RedemptionCode(
+                code="WARRANTY-RECALC-001",
+                status="used",
+                has_warranty=True,
+                warranty_days=30,
+                used_by_email="user@example.com",
+                used_team_id=201,
+                used_at=get_now() - timedelta(days=1),
+                warranty_expires_at=get_now() + timedelta(days=20),
+            )
+            first_record = RedemptionRecord(
+                email="user@example.com",
+                code="WARRANTY-RECALC-001",
+                team_id=201,
+                account_id="acct-auto-kick",
+                redeemed_at=get_now() - timedelta(days=40),
+                is_warranty_redemption=True,
+            )
+            second_record = RedemptionRecord(
+                email="user@example.com",
+                code="WARRANTY-RECALC-001",
+                team_id=201,
+                account_id="acct-auto-kick",
+                redeemed_at=get_now() - timedelta(days=1),
+                is_warranty_redemption=True,
+            )
+            session.add_all([
+                code,
+                first_record,
+                second_record,
+                Setting(key="warranty_expiration_mode", value="first_use"),
+            ])
+            await session.commit()
+
+            service = WarrantyService()
+            result = await service.scan_expired_warranty_codes(session)
+
+            self.assertTrue(result["success"])
+            self.assertEqual(result["total"], 1)
+            self.assertEqual(result["codes"][0]["code"], "WARRANTY-RECALC-001")
+
+    async def test_kick_and_destroy_expired_warranty_code_removes_records_and_code(self):
+        async with self.session_factory() as session:
+            team = Team(
+                id=202,
+                email="owner@example.com",
+                access_token_encrypted="token-1",
+                account_id="acct-auto-kick-2",
+                team_name="Kick Team",
+                current_members=1,
+                max_members=5,
+                status="active",
+                pool_type="normal",
+            )
+            session.add(team)
+            await session.commit()
+
+            code = RedemptionCode(
+                code="WARRANTY-KICK-001",
+                status="used",
+                has_warranty=True,
+                warranty_days=30,
+                used_by_email="member@example.com",
+                used_team_id=202,
+                used_at=get_now() - timedelta(days=35),
+                warranty_expires_at=get_now() - timedelta(days=5),
+            )
+            record = RedemptionRecord(
+                email="member@example.com",
+                code="WARRANTY-KICK-001",
+                team_id=202,
+                account_id="acct-auto-kick-2",
+                redeemed_at=get_now() - timedelta(days=35),
+                is_warranty_redemption=True,
+            )
+            session.add_all([
+                code,
+                record,
+                Setting(key="warranty_expiration_mode", value="refresh_on_redeem"),
+            ])
+            await session.commit()
+
+            service = WarrantyService()
+
+            async def stub_remove_invite_or_member(team_id, email, db_session):
+                self.assertEqual(team_id, 202)
+                self.assertEqual(email, "member@example.com")
+                return {"success": True, "message": "成员已删除", "error": None}
+
+            service.team_service.remove_invite_or_member = stub_remove_invite_or_member
+
+            result = await service.kick_and_destroy_expired_warranty_code(session, "WARRANTY-KICK-001")
+
+            self.assertTrue(result["success"])
+            self.assertEqual(result["action"], "kicked_and_destroyed")
+
+            remaining_code = await session.execute(
+                select(RedemptionCode).where(RedemptionCode.code == "WARRANTY-KICK-001")
+            )
+            self.assertIsNone(remaining_code.scalar_one_or_none())
+
+            remaining_records = await session.execute(
+                select(RedemptionRecord).where(RedemptionRecord.code == "WARRANTY-KICK-001")
+            )
+            self.assertEqual(list(remaining_records.scalars().all()), [])
+
+
 class TeamServiceBulkInviteTests(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         self.engine = create_async_engine("sqlite+aiosqlite:///:memory:")


### PR DESCRIPTION
Add a dedicated settings panel and scheduler job so expired warranty redemptions are recalculated with the active mode, removed from their Team, and destroyed to prevent reuse.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lolollipop/team-manage-refresh/pull/175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
