### PR TITLE
feat(warranty): add renewal reminders and pending tasks

### DIFF
--- a/app/db_migrations.py
+++ b/app/db_migrations.py
@@ -137,6 +137,11 @@ def run_auto_migration():
             cursor.execute("ALTER TABLE redemption_codes ADD COLUMN reusable_by_seat BOOLEAN DEFAULT 0")
             migrations_applied.append("redemption_codes.reusable_by_seat")
 
+        if not column_exists(cursor, "redemption_codes", "extension_days"):
+            logger.info("添加 redemption_codes.extension_days 字段")
+            cursor.execute("ALTER TABLE redemption_codes ADD COLUMN extension_days INTEGER DEFAULT 0")
+            migrations_applied.append("redemption_codes.extension_days")
+
         if not table_exists(cursor, "team_email_mappings"):
             logger.info("创建 team_email_mappings 表")
             cursor.execute("""
@@ -174,6 +179,38 @@ def run_auto_migration():
         cursor.execute("""
             CREATE INDEX IF NOT EXISTS idx_team_email_status
             ON team_email_mappings (team_id, status)
+        """)
+
+        if not table_exists(cursor, "renewal_requests"):
+            logger.info("创建 renewal_requests 表")
+            cursor.execute("""
+                CREATE TABLE renewal_requests (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    email VARCHAR(255) NOT NULL,
+                    code VARCHAR(32) NOT NULL,
+                    team_id INTEGER,
+                    status VARCHAR(20) NOT NULL DEFAULT 'pending',
+                    requested_at DATETIME,
+                    handled_at DATETIME,
+                    extension_days INTEGER,
+                    admin_note TEXT,
+                    FOREIGN KEY(code) REFERENCES redemption_codes(code) ON DELETE CASCADE,
+                    FOREIGN KEY(team_id) REFERENCES teams(id)
+                )
+            """)
+            migrations_applied.append("renewal_requests")
+
+        cursor.execute("""
+            CREATE INDEX IF NOT EXISTS idx_renewal_request_status
+            ON renewal_requests (status)
+        """)
+        cursor.execute("""
+            CREATE INDEX IF NOT EXISTS idx_renewal_request_email
+            ON renewal_requests (email)
+        """)
+        cursor.execute("""
+            CREATE INDEX IF NOT EXISTS idx_renewal_request_code
+            ON renewal_requests (code)
         """)
 
         # 提交更改

--- a/app/models.py
+++ b/app/models.py
@@ -106,12 +106,14 @@ class RedemptionCode(Base):
     used_at = Column(DateTime, comment="使用时间")
     has_warranty = Column(Boolean, default=False, comment="是否为质保兑换码")
     warranty_days = Column(Integer, default=30, comment="质保时长(天)")
+    extension_days = Column(Integer, default=0, comment="人工续期累计天数")
     warranty_expires_at = Column(DateTime, comment="质保到期时间(首次使用后根据质保时长计算)")
     pool_type = Column(String(20), default="normal", comment="兑换池类型: normal/welfare")
     reusable_by_seat = Column(Boolean, default=False, comment="是否可按席位重复使用")
 
     # 关系
     redemption_records = relationship("RedemptionRecord", back_populates="redemption_code")
+    renewal_requests = relationship("RenewalRequest", back_populates="redemption_code")
 
     # 索引
     __table_args__ = (
@@ -138,6 +140,30 @@ class RedemptionRecord(Base):
     # 索引
     __table_args__ = (
         Index("idx_email", "email"),
+    )
+
+
+class RenewalRequest(Base):
+    """兑换码续期请求表"""
+    __tablename__ = "renewal_requests"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    email = Column(String(255), nullable=False, comment="申请续期的用户邮箱")
+    code = Column(String(32), ForeignKey("redemption_codes.code", ondelete="CASCADE"), nullable=False, comment="兑换码")
+    team_id = Column(Integer, ForeignKey("teams.id"), comment="申请时关联的 Team ID")
+    status = Column(String(20), default="pending", nullable=False, comment="状态: pending/extended/ignored")
+    requested_at = Column(DateTime, default=get_now, comment="申请时间")
+    handled_at = Column(DateTime, comment="处理时间")
+    extension_days = Column(Integer, comment="管理员批准的续期天数")
+    admin_note = Column(Text, comment="管理员备注")
+
+    # 关系
+    redemption_code = relationship("RedemptionCode", back_populates="renewal_requests")
+
+    __table_args__ = (
+        Index("idx_renewal_request_status", "status"),
+        Index("idx_renewal_request_email", "email"),
+        Index("idx_renewal_request_code", "code"),
     )
 
 

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -8,7 +8,7 @@ import logging
 import re
 import zipfile
 from io import BytesIO
-from typing import Optional, List, Dict, Literal
+from typing import Any, Optional, List, Dict, Literal
 from fastapi import APIRouter, Depends, HTTPException, Query, status, Request
 from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse, Response
 from sqlalchemy import select, func, update
@@ -26,7 +26,7 @@ from app.services.settings import (
     DEFAULT_UI_THEME,
 )
 from app.services.cliproxyapi import cliproxyapi_service
-from app.models import RedemptionCode, RedemptionRecord, Team
+from app.models import RedemptionCode, RedemptionRecord, RenewalRequest, Team
 from app.utils.time_utils import get_now
 from app.utils.proxy import mask_proxy_url, normalize_proxy_url
 
@@ -49,6 +49,29 @@ async def resolve_ui_theme(db: AsyncSession) -> str:
         await settings_service.get_setting(db, "ui_theme", DEFAULT_UI_THEME)
     )
 
+
+async def get_pending_renewal_request_count(db: AsyncSession) -> int:
+    """获取待处理续期请求数量。"""
+    result = await db.execute(
+        select(func.count(RenewalRequest.id)).where(RenewalRequest.status == "pending")
+    )
+    return int(result.scalar() or 0)
+
+
+async def build_admin_base_context(
+    request: Request,
+    db: AsyncSession,
+    current_user: dict,
+    active_page: str,
+) -> Dict[str, Any]:
+    """构建后台页面通用模板上下文。"""
+    return {
+        "request": request,
+        "user": current_user,
+        "active_page": active_page,
+        "ui_theme": await resolve_ui_theme(db),
+        "pending_renewal_request_count": await get_pending_renewal_request_count(db),
+    }
 
 
 # 请求模型
@@ -209,25 +232,23 @@ async def admin_dashboard(
             "expired_teams": team_stats["expired"],
         }
 
+        context = await build_admin_base_context(request, db, current_user, "dashboard")
+        context.update({
+            "teams": teams_result.get("teams", []),
+            "stats": stats,
+            "search": search,
+            "status_filter": status_filter,
+            "pagination": {
+                "current_page": teams_result.get("current_page", page),
+                "total_pages": teams_result.get("total_pages", 1),
+                "total": teams_result.get("total", 0),
+                "per_page": per_page
+            }
+        })
         return templates.TemplateResponse(
             request,
             "admin/index.html",
-            {
-                "request": request,
-                "user": current_user,
-                "active_page": "dashboard",
-                "ui_theme": await resolve_ui_theme(db),
-                "teams": teams_result.get("teams", []),
-                "stats": stats,
-                "search": search,
-                "status_filter": status_filter,
-                "pagination": {
-                    "current_page": teams_result.get("current_page", page),
-                    "total_pages": teams_result.get("total_pages", 1),
-                    "total": teams_result.get("total", 0),
-                    "per_page": per_page
-                }
-            }
+            context,
         )
     except Exception as e:
         logger.exception("加载管理员面板失败")
@@ -281,25 +302,23 @@ async def welfare_dashboard(
             "welfare_code_team_email": welfare_usage.get("team_email"),
         }
 
+        context = await build_admin_base_context(request, db, current_user, "welfare")
+        context.update({
+            "teams": teams_result.get("teams", []),
+            "stats": stats,
+            "search": search,
+            "status_filter": status_filter,
+            "pagination": {
+                "current_page": teams_result.get("current_page", page),
+                "total_pages": teams_result.get("total_pages", 1),
+                "total": teams_result.get("total", 0),
+                "per_page": per_page
+            }
+        })
         return templates.TemplateResponse(
             request,
             "admin/index.html",
-            {
-                "request": request,
-                "user": current_user,
-                "active_page": "welfare",
-                "ui_theme": await resolve_ui_theme(db),
-                "teams": teams_result.get("teams", []),
-                "stats": stats,
-                "search": search,
-                "status_filter": status_filter,
-                "pagination": {
-                    "current_page": teams_result.get("current_page", page),
-                    "total_pages": teams_result.get("total_pages", 1),
-                    "total": teams_result.get("total", 0),
-                    "per_page": per_page
-                }
-            }
+            context,
         )
     except Exception as e:
         logger.exception("加载福利车位页面失败")
@@ -1551,25 +1570,23 @@ async def codes_list_page(
                 dt = datetime.fromisoformat(code["used_at"])
                 code["used_at"] = dt.strftime("%Y-%m-%d %H:%M")
 
+        context = await build_admin_base_context(request, db, current_user, "codes")
+        context.update({
+            "codes": codes,
+            "stats": stats,
+            "search": search,
+            "status_filter": status_filter,
+            "pagination": {
+                "current_page": current_page,
+                "total_pages": total_pages,
+                "total": total_codes,
+                "per_page": per_page
+            }
+        })
         return templates.TemplateResponse(
             request,
             "admin/codes/index.html",
-            {
-                "request": request,
-                "user": current_user,
-                "active_page": "codes",
-                "ui_theme": await resolve_ui_theme(db),
-                "codes": codes,
-                "stats": stats,
-                "search": search,
-                "status_filter": status_filter,
-                "pagination": {
-                    "current_page": current_page,
-                    "total_pages": total_pages,
-                    "total": total_codes,
-                    "per_page": per_page
-                }
-            }
+            context,
         )
 
     except Exception as e:
@@ -2073,30 +2090,28 @@ async def records_page(
             except:
                 pass
 
+        context = await build_admin_base_context(request, db, current_user, "records")
+        context.update({
+            "records": paginated_records,
+            "stats": stats,
+            "filters": {
+                "email": email,
+                "code": code,
+                "team_id": team_id,
+                "start_date": start_date,
+                "end_date": end_date
+            },
+            "pagination": {
+                "current_page": page_int,
+                "total_pages": total_pages,
+                "total": total_records,
+                "per_page": per_page
+            }
+        })
         return templates.TemplateResponse(
             request,
             "admin/records/index.html",
-            {
-                "request": request,
-                "user": current_user,
-                "active_page": "records",
-                "ui_theme": await resolve_ui_theme(db),
-                "records": paginated_records,
-                "stats": stats,
-                "filters": {
-                    "email": email,
-                    "code": code,
-                    "team_id": team_id,
-                    "start_date": start_date,
-                    "end_date": end_date
-                },
-                "pagination": {
-                    "current_page": page_int,
-                    "total_pages": total_pages,
-                    "total": total_records,
-                    "per_page": per_page
-                }
-            }
+            context,
         )
 
     except Exception as e:
@@ -2174,34 +2189,33 @@ async def settings_page(
         proxy_config = await settings_service.get_proxy_config(db)
         log_level = await settings_service.get_log_level(db)
 
+        context = await build_admin_base_context(request, db, current_user, "settings")
+        context.update({
+            "proxy_enabled": proxy_config["enabled"],
+            "proxy": proxy_config["proxy"],
+            "log_level": log_level,
+            "webhook_url": await settings_service.get_setting(db, "webhook_url", ""),
+            "low_stock_threshold": await settings_service.get_setting(db, "low_stock_threshold", "10"),
+            "api_key": await settings_service.get_setting(db, "api_key", ""),
+            "token_refresh_interval_minutes": await settings_service.get_setting(db, "token_refresh_interval_minutes", "30"),
+            "token_refresh_window_hours": await settings_service.get_setting(db, "token_refresh_window_hours", "2"),
+            "token_refresh_client_id": await settings_service.get_setting(db, "token_refresh_client_id", ""),
+            "periodic_team_sync_enabled": await settings_service.get_setting(db, "periodic_team_sync_enabled", "true"),
+            "periodic_team_sync_interval_hours": await settings_service.get_setting(db, "periodic_team_sync_interval_hours", "12"),
+            "periodic_team_sync_days": await settings_service.get_setting(db, "periodic_team_sync_days", "7"),
+            "warranty_auto_kick_enabled": await settings_service.get_setting(db, "warranty_auto_kick_enabled", "false"),
+            "warranty_auto_kick_interval_hours": await settings_service.get_setting(db, "warranty_auto_kick_interval_hours", "12"),
+            "warranty_renewal_reminder_days": await settings_service.get_setting(db, "warranty_renewal_reminder_days", "7"),
+            "default_team_max_members": await settings_service.get_setting(db, "default_team_max_members", "6"),
+            "cliproxyapi_base_url": await settings_service.get_setting(db, "cliproxyapi_base_url", ""),
+            "cliproxyapi_api_key": await settings_service.get_setting(db, "cliproxyapi_api_key", ""),
+            "warranty_expiration_mode": await settings_service.get_warranty_expiration_mode(db),
+            "ui_theme": settings_service.normalize_ui_theme(await settings_service.get_setting(db, "ui_theme", DEFAULT_UI_THEME)),
+        })
         return templates.TemplateResponse(
             request,
             "admin/settings/index.html",
-            {
-                "request": request,
-                "user": current_user,
-                "active_page": "settings",
-                "ui_theme": await resolve_ui_theme(db),
-                "proxy_enabled": proxy_config["enabled"],
-                "proxy": proxy_config["proxy"],
-                "log_level": log_level,
-                "webhook_url": await settings_service.get_setting(db, "webhook_url", ""),
-                "low_stock_threshold": await settings_service.get_setting(db, "low_stock_threshold", "10"),
-                "api_key": await settings_service.get_setting(db, "api_key", ""),
-                "token_refresh_interval_minutes": await settings_service.get_setting(db, "token_refresh_interval_minutes", "30"),
-                "token_refresh_window_hours": await settings_service.get_setting(db, "token_refresh_window_hours", "2"),
-                "token_refresh_client_id": await settings_service.get_setting(db, "token_refresh_client_id", ""),
-                "periodic_team_sync_enabled": await settings_service.get_setting(db, "periodic_team_sync_enabled", "true"),
-                "periodic_team_sync_interval_hours": await settings_service.get_setting(db, "periodic_team_sync_interval_hours", "12"),
-                "periodic_team_sync_days": await settings_service.get_setting(db, "periodic_team_sync_days", "7"),
-                "warranty_auto_kick_enabled": await settings_service.get_setting(db, "warranty_auto_kick_enabled", "false"),
-                "warranty_auto_kick_interval_hours": await settings_service.get_setting(db, "warranty_auto_kick_interval_hours", "12"),
-                "default_team_max_members": await settings_service.get_setting(db, "default_team_max_members", "6"),
-                "cliproxyapi_base_url": await settings_service.get_setting(db, "cliproxyapi_base_url", ""),
-                "cliproxyapi_api_key": await settings_service.get_setting(db, "cliproxyapi_api_key", ""),
-                "warranty_expiration_mode": await settings_service.get_warranty_expiration_mode(db),
-                "ui_theme": settings_service.normalize_ui_theme(await settings_service.get_setting(db, "ui_theme", DEFAULT_UI_THEME)),
-            }
+            context,
         )
 
     except Exception as e:
@@ -2259,6 +2273,7 @@ class WarrantyAutoKickSettingsRequest(BaseModel):
     """质保过期自动踢人设置请求"""
     enabled: bool = Field(False, description="是否启用质保过期自动踢人")
     interval_hours: int = Field(12, ge=1, le=168, description="检查间隔（小时）")
+    renewal_reminder_days: int = Field(7, ge=1, le=30, description="距离质保结束多少天内提醒续期")
 
 
 class WarrantyExpirationSettingsRequest(BaseModel):
@@ -2280,6 +2295,10 @@ class AnnouncementUpdateRequest(BaseModel):
     markdown: str = Field("", description="公告 Markdown 内容")
 
 
+class RenewalRequestAction(BaseModel):
+    """续期请求处理请求"""
+    extension_days: Optional[int] = Field(None, ge=1, le=365, description="续期天数")
+    admin_note: str = Field("", description="管理员备注")
 
 
 @router.get("/settings/ui-theme")
@@ -2337,17 +2356,15 @@ async def announcement_page(
         announcement_enabled = str(enabled_raw).lower() in {"1", "true", "yes", "on"}
         announcement_markdown = await settings_service.get_setting(db, "announcement_markdown", "")
 
+        context = await build_admin_base_context(request, db, current_user, "announcement")
+        context.update({
+            "announcement_enabled": announcement_enabled,
+            "announcement_markdown": announcement_markdown,
+        })
         return templates.TemplateResponse(
             request,
             "admin/announcement/index.html",
-            {
-                "request": request,
-                "user": current_user,
-                "active_page": "announcement",
-                "ui_theme": await resolve_ui_theme(db),
-                "announcement_enabled": announcement_enabled,
-                "announcement_markdown": announcement_markdown,
-            }
+            context,
         )
     except Exception as e:
         logger.exception("获取公告设置失败")
@@ -2385,6 +2402,100 @@ async def update_announcement(
         return JSONResponse(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             content={"success": False, "error": "保存失败，请稍后重试"}
+        )
+
+
+@router.get("/renewal-requests", response_class=HTMLResponse)
+async def renewal_requests_page(
+    request: Request,
+    status_filter: Optional[str] = None,
+    db: AsyncSession = Depends(get_db),
+    current_user: dict = Depends(require_admin)
+):
+    """待处理续期任务页面。"""
+    try:
+        from app.main import templates
+
+        result = await warranty_service.get_renewal_requests(db, status_filter=status_filter)
+        if not result.get("success"):
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=result.get("error") or "获取续期请求失败",
+            )
+
+        context = await build_admin_base_context(request, db, current_user, "renewal_requests")
+        context.update({
+            "renewal_requests": result.get("requests", []),
+            "stats": {
+                "total": result.get("total", 0),
+                "pending": result.get("pending_count", 0),
+                "extended": sum(1 for item in result.get("requests", []) if item.get("status") == "extended"),
+                "ignored": sum(1 for item in result.get("requests", []) if item.get("status") == "ignored"),
+            },
+            "status_filter": status_filter,
+        })
+        return templates.TemplateResponse(
+            request,
+            "admin/renewal_requests/index.html",
+            context,
+        )
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("获取续期任务页面失败")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="获取续期任务页面失败，请稍后重试",
+        )
+
+
+@router.post("/renewal-requests/{request_id}/extend")
+async def extend_renewal_request(
+    request_id: int,
+    payload: RenewalRequestAction,
+    db: AsyncSession = Depends(get_db),
+    current_user: dict = Depends(require_admin)
+):
+    """续期请求立即生效。"""
+    try:
+        extension_days = int(payload.extension_days or 0)
+        result = await warranty_service.extend_warranty_request(
+            db,
+            request_id=request_id,
+            extension_days=extension_days,
+            admin_note=payload.admin_note,
+        )
+        status_code = status.HTTP_200_OK if result.get("success") else status.HTTP_400_BAD_REQUEST
+        return JSONResponse(status_code=status_code, content=result)
+    except Exception:
+        logger.exception("处理续期请求失败")
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content={"success": False, "error": "处理续期请求失败，请稍后重试"},
+        )
+
+
+@router.post("/renewal-requests/{request_id}/ignore")
+async def ignore_renewal_request(
+    request_id: int,
+    payload: RenewalRequestAction,
+    db: AsyncSession = Depends(get_db),
+    current_user: dict = Depends(require_admin)
+):
+    """忽略续期请求。"""
+    try:
+        result = await warranty_service.ignore_renewal_request(
+            db,
+            request_id=request_id,
+            admin_note=payload.admin_note,
+        )
+        status_code = status.HTTP_200_OK if result.get("success") else status.HTTP_400_BAD_REQUEST
+        return JSONResponse(status_code=status_code, content=result)
+    except Exception:
+        logger.exception("忽略续期请求失败")
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content={"success": False, "error": "忽略续期请求失败，请稍后重试"},
         )
 
 
@@ -2706,9 +2817,10 @@ async def update_warranty_auto_kick_settings(
         from app.main import configure_warranty_auto_kick_job
 
         logger.info(
-            "管理员更新质保过期自动踢人配置: enabled=%s, interval_hours=%s",
+            "管理员更新质保过期自动踢人配置: enabled=%s, interval_hours=%s, reminder_days=%s",
             auto_kick_data.enabled,
             auto_kick_data.interval_hours,
+            auto_kick_data.renewal_reminder_days,
         )
 
         success = await settings_service.update_settings(
@@ -2716,6 +2828,7 @@ async def update_warranty_auto_kick_settings(
             {
                 "warranty_auto_kick_enabled": str(auto_kick_data.enabled).lower(),
                 "warranty_auto_kick_interval_hours": str(auto_kick_data.interval_hours),
+                "warranty_renewal_reminder_days": str(auto_kick_data.renewal_reminder_days),
             }
         )
         if not success:
@@ -2740,6 +2853,7 @@ async def update_warranty_auto_kick_settings(
                 "message": message,
                 "enabled": auto_kick_data.enabled,
                 "interval_hours": applied_interval,
+                "renewal_reminder_days": auto_kick_data.renewal_reminder_days,
             }
         )
     except Exception:

--- a/app/routes/warranty.py
+++ b/app/routes/warranty.py
@@ -37,6 +37,10 @@ class WarrantyCheckRecord(BaseModel):
     team_expires_at: Optional[str]
     email: Optional[str] = None
     device_code_auth_enabled: bool = False
+    remaining_warranty_days: Optional[int] = None
+    auto_kick_enabled: bool = False
+    renewal_reminder_days: Optional[int] = None
+    should_show_renewal_reminder: bool = False
 
 
 class WarrantyCheckResponse(BaseModel):
@@ -112,9 +116,45 @@ async def check_warranty(
         )
 
 
+class WarrantyRenewalRequest(BaseModel):
+    """用户提交续期请求"""
+    email: EmailStr
+    code: str
+    team_id: Optional[int] = None
+    source: Optional[str] = None
+
+
 class EnableDeviceAuthRequest(BaseModel):
     """开启设备身份验证请求"""
     team_id: int
+
+
+@router.post("/renewal-request")
+async def create_warranty_renewal_request(
+    request: WarrantyRenewalRequest,
+    db_session: AsyncSession = Depends(get_db)
+):
+    """提交质保续期请求。"""
+    try:
+        result = await warranty_service.create_renewal_request(
+            db_session,
+            email=request.email,
+            code=request.code,
+            team_id=request.team_id,
+        )
+        if not result.get("success"):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=result.get("error") or "提交失败",
+            )
+        return result
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="提交续期请求失败，请稍后重试"
+        )
 
 
 @router.post("/enable-device-auth")

--- a/app/services/redeem_flow.py
+++ b/app/services/redeem_flow.py
@@ -583,7 +583,8 @@ class RedeemFlowService:
                                 if (not rc.has_warranty) or should_refresh_warranty_window:
                                     rc.used_at = current_use_time
                                 if rc.has_warranty:
-                                    days = rc.warranty_days or 30
+                                    extension_days = max(int(getattr(rc, "extension_days", 0) or 0), 0)
+                                    days = (rc.warranty_days or 30) + extension_days
                                     if should_refresh_warranty_window:
                                         rc.warranty_expires_at = current_use_time + timedelta(days=days)
                                     elif not rc.warranty_expires_at:

--- a/app/services/redemption.py
+++ b/app/services/redemption.py
@@ -74,6 +74,13 @@ class RedemptionService:
             return default
 
     @staticmethod
+    def _effective_warranty_days(redemption_code: RedemptionCode) -> int:
+        """获取兑换码当前总质保天数（基础时长 + 人工续期）。"""
+        base_days = int(redemption_code.warranty_days or 30)
+        extension_days = max(int(getattr(redemption_code, "extension_days", 0) or 0), 0)
+        return base_days + extension_days
+
+    @staticmethod
     def _sync_code_status_fields(redemption_code: RedemptionCode) -> bool:
         """按当前时间同步兑换码状态，避免状态被错误地长期停留在过期态。"""
         now = get_now()
@@ -550,7 +557,7 @@ class RedemptionService:
             )
             base_time = base_record.redeemed_at or get_now()
             redemption_code.used_at = base_time
-            days = redemption_code.warranty_days or 30
+            days = self._effective_warranty_days(redemption_code)
             redemption_code.warranty_expires_at = base_time + timedelta(days=days)
         else:
             redemption_code.used_at = latest_record.redeemed_at or get_now()
@@ -1116,6 +1123,7 @@ class RedemptionService:
                     "used_at": code.used_at.isoformat() if code.used_at else None,
                     "has_warranty": code.has_warranty,
                     "warranty_days": code.warranty_days,
+                    "extension_days": int(getattr(code, "extension_days", 0) or 0),
                     "warranty_expires_at": code.warranty_expires_at.isoformat() if code.warranty_expires_at else None,
                     "can_delete": record_counts.get(code.code, 0) == 0
                 })

--- a/app/services/warranty.py
+++ b/app/services/warranty.py
@@ -10,7 +10,7 @@ from sqlalchemy import select, and_, or_, delete, func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.models import RedemptionCode, RedemptionRecord, Team
+from app.models import RedemptionCode, RedemptionRecord, RenewalRequest, Team
 from app.services.settings import (
     settings_service,
     WARRANTY_EXPIRATION_MODE_REFRESH_ON_REDEEM,
@@ -50,6 +50,13 @@ class WarrantyService:
         """初始化质保服务"""
         from app.services.team import TeamService
         self.team_service = TeamService()
+
+    @staticmethod
+    def _get_total_warranty_days(redemption_code: RedemptionCode) -> int:
+        """获取兑换码当前总质保天数（基础时长 + 人工续期）。"""
+        base_days = int(redemption_code.warranty_days or 30)
+        extension_days = max(int(getattr(redemption_code, "extension_days", 0) or 0), 0)
+        return base_days + extension_days
 
     async def _get_warranty_start_time(
         self,
@@ -96,7 +103,7 @@ class WarrantyService:
         if not start_time:
             return None
 
-        days = redemption_code.warranty_days or 30
+        days = self._get_total_warranty_days(redemption_code)
         return start_time + timedelta(days=days)
 
     @staticmethod
@@ -109,6 +116,217 @@ class WarrantyService:
             return True
 
         return False
+
+    @staticmethod
+    def _remaining_warranty_days(expiry_date: Optional[datetime]) -> Optional[int]:
+        """计算剩余质保天数，按自然日向上取整。"""
+        if not expiry_date:
+            return None
+        delta = expiry_date - get_now()
+        if delta.total_seconds() <= 0:
+            return 0
+        return max(int((delta.total_seconds() + 86399) // 86400), 0)
+
+    async def _get_renewal_reminder_days(self, db_session: AsyncSession) -> int:
+        """获取续期提醒阈值。"""
+        raw_value = await settings_service.get_setting(
+            db_session,
+            "warranty_renewal_reminder_days",
+            "7",
+        )
+        try:
+            reminder_days = int(str(raw_value or "7").strip())
+        except Exception:
+            reminder_days = 7
+        return max(1, min(30, reminder_days))
+
+    async def get_pending_renewal_request_count(self, db_session: AsyncSession) -> int:
+        """获取待处理续期请求数量。"""
+        result = await db_session.execute(
+            select(func.count(RenewalRequest.id)).where(RenewalRequest.status == "pending")
+        )
+        return int(result.scalar() or 0)
+
+    async def create_renewal_request(
+        self,
+        db_session: AsyncSession,
+        email: str,
+        code: str,
+        team_id: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """创建续期请求；若已存在 pending 请求则直接返回成功。"""
+        normalized_email = self.team_service._normalize_member_email(email)
+        normalized_code = str(code or "").strip()
+        if not normalized_email or not normalized_code:
+            return {"success": False, "error": "邮箱或兑换码不能为空"}
+
+        existing_result = await db_session.execute(
+            select(RenewalRequest).where(
+                RenewalRequest.email == normalized_email,
+                RenewalRequest.code == normalized_code,
+                RenewalRequest.status == "pending",
+            )
+        )
+        existing = existing_result.scalar_one_or_none()
+        if existing:
+            return {
+                "success": True,
+                "message": "续期请求已提交，请勿重复提交",
+                "request_id": existing.id,
+                "duplicated": True,
+            }
+
+        code_result = await db_session.execute(
+            select(RedemptionCode).where(RedemptionCode.code == normalized_code)
+        )
+        redemption_code = code_result.scalar_one_or_none()
+        if not redemption_code:
+            return {"success": False, "error": "兑换码不存在或已销毁"}
+
+        request = RenewalRequest(
+            email=normalized_email,
+            code=normalized_code,
+            team_id=team_id,
+            status="pending",
+        )
+        db_session.add(request)
+        await db_session.commit()
+
+        return {
+            "success": True,
+            "message": "已通知管理员处理续期请求",
+            "request_id": request.id,
+            "duplicated": False,
+        }
+
+    async def get_renewal_requests(
+        self,
+        db_session: AsyncSession,
+        status_filter: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """获取续期请求列表。"""
+        stmt = select(RenewalRequest).order_by(RenewalRequest.requested_at.desc(), RenewalRequest.id.desc())
+        if status_filter:
+            stmt = stmt.where(RenewalRequest.status == status_filter)
+
+        result = await db_session.execute(stmt)
+        requests = result.scalars().all()
+        items: List[Dict[str, Any]] = []
+        pending_count = 0
+
+        for request in requests:
+            code_result = await db_session.execute(
+                select(RedemptionCode).where(RedemptionCode.code == request.code)
+            )
+            redemption_code = code_result.scalar_one_or_none()
+            remaining_days: Optional[int] = None
+            expiry_iso: Optional[str] = None
+            code_exists = redemption_code is not None
+            if redemption_code and redemption_code.has_warranty:
+                expiry_date = await self._resolve_warranty_expiry_date(
+                    db_session,
+                    redemption_code,
+                    force_recompute=True,
+                )
+                remaining_days = self._remaining_warranty_days(expiry_date)
+                expiry_iso = expiry_date.isoformat() if expiry_date else None
+
+            if request.status == "pending":
+                pending_count += 1
+
+            items.append({
+                "id": request.id,
+                "email": request.email,
+                "code": request.code,
+                "team_id": request.team_id,
+                "status": request.status,
+                "requested_at": request.requested_at.isoformat() if request.requested_at else None,
+                "handled_at": request.handled_at.isoformat() if request.handled_at else None,
+                "extension_days": request.extension_days,
+                "admin_note": request.admin_note,
+                "remaining_warranty_days": remaining_days,
+                "warranty_expires_at": expiry_iso,
+                "code_exists": code_exists,
+            })
+
+        return {
+            "success": True,
+            "requests": items,
+            "pending_count": pending_count,
+            "total": len(items),
+        }
+
+    async def extend_warranty_request(
+        self,
+        db_session: AsyncSession,
+        request_id: int,
+        extension_days: int,
+        admin_note: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """处理续期请求并立即生效。"""
+        if extension_days <= 0:
+            return {"success": False, "error": "续期天数必须大于 0"}
+
+        request_result = await db_session.execute(
+            select(RenewalRequest).where(RenewalRequest.id == request_id)
+        )
+        renewal_request = request_result.scalar_one_or_none()
+        if not renewal_request:
+            return {"success": False, "error": "续期请求不存在"}
+
+        code_result = await db_session.execute(
+            select(RedemptionCode).where(RedemptionCode.code == renewal_request.code)
+        )
+        redemption_code = code_result.scalar_one_or_none()
+        if not redemption_code:
+            renewal_request.status = "ignored"
+            renewal_request.handled_at = get_now()
+            renewal_request.admin_note = admin_note or "兑换码不存在或已销毁"
+            await db_session.commit()
+            return {"success": False, "error": "兑换码不存在或已销毁，无法续期"}
+
+        redemption_code.extension_days = int(getattr(redemption_code, "extension_days", 0) or 0) + extension_days
+        expiry_date = await self._resolve_warranty_expiry_date(
+            db_session,
+            redemption_code,
+            force_recompute=True,
+        )
+        redemption_code.warranty_expires_at = expiry_date
+        if expiry_date and expiry_date >= get_now() and redemption_code.used_at:
+            redemption_code.status = "used"
+
+        renewal_request.status = "extended"
+        renewal_request.handled_at = get_now()
+        renewal_request.extension_days = extension_days
+        renewal_request.admin_note = (admin_note or "").strip() or None
+        await db_session.commit()
+
+        return {
+            "success": True,
+            "message": f"已成功续期 {extension_days} 天",
+            "warranty_expires_at": expiry_date.isoformat() if expiry_date else None,
+            "remaining_warranty_days": self._remaining_warranty_days(expiry_date),
+        }
+
+    async def ignore_renewal_request(
+        self,
+        db_session: AsyncSession,
+        request_id: int,
+        admin_note: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """忽略续期请求。"""
+        request_result = await db_session.execute(
+            select(RenewalRequest).where(RenewalRequest.id == request_id)
+        )
+        renewal_request = request_result.scalar_one_or_none()
+        if not renewal_request:
+            return {"success": False, "error": "续期请求不存在"}
+
+        renewal_request.status = "ignored"
+        renewal_request.handled_at = get_now()
+        renewal_request.admin_note = (admin_note or "").strip() or None
+        await db_session.commit()
+        return {"success": True, "message": "已忽略该续期请求"}
 
     async def check_warranty_status(
         self,
@@ -148,6 +366,13 @@ class WarrantyService:
                 }
             _query_rate_limit[limit_key] = now
             warranty_expiration_mode = await settings_service.get_warranty_expiration_mode(db_session)
+            auto_kick_enabled_raw = await settings_service.get_setting(
+                db_session,
+                "warranty_auto_kick_enabled",
+                "false",
+            )
+            auto_kick_enabled = str(auto_kick_enabled_raw).lower() in {"1", "true", "yes", "on"}
+            renewal_reminder_days = await self._get_renewal_reminder_days(db_session)
 
             # 1. 查找兑换记录和相关联的 Team, Code
             records_data = []
@@ -288,6 +513,7 @@ class WarrantyService:
                             "为避免误删售后证据，本次仅标记异常，不执行自动清理。"
                         )
                         suspected_inconsistent_count += 1
+                        remaining_days = self._remaining_warranty_days(expiry_date)
                         final_records.append({
                             "code": code_obj.code,
                             "has_warranty": code_obj.has_warranty,
@@ -300,7 +526,17 @@ class WarrantyService:
                             "team_status": "suspected_inconsistent",
                             "team_expires_at": team.expires_at.isoformat() if team.expires_at else None,
                             "email": record.email,
-                            "device_code_auth_enabled": team.device_code_auth_enabled
+                            "device_code_auth_enabled": team.device_code_auth_enabled,
+                            "remaining_warranty_days": remaining_days,
+                            "auto_kick_enabled": auto_kick_enabled,
+                            "renewal_reminder_days": renewal_reminder_days,
+                            "should_show_renewal_reminder": bool(
+                                code_obj.has_warranty
+                                and is_valid
+                                and auto_kick_enabled
+                                and remaining_days is not None
+                                and remaining_days <= renewal_reminder_days
+                            ),
                         })
                         continue
 
@@ -330,6 +566,7 @@ class WarrantyService:
                         "banned_at": team.last_sync.isoformat() if team.last_sync else None
                     })
 
+                remaining_days = self._remaining_warranty_days(expiry_date)
                 final_records.append({
                     "code": code_obj.code,
                     "has_warranty": code_obj.has_warranty,
@@ -342,7 +579,17 @@ class WarrantyService:
                     "team_status": team.status,
                     "team_expires_at": team.expires_at.isoformat() if team.expires_at else None,
                     "email": record.email,
-                    "device_code_auth_enabled": team.device_code_auth_enabled
+                    "device_code_auth_enabled": team.device_code_auth_enabled,
+                    "remaining_warranty_days": remaining_days,
+                    "auto_kick_enabled": auto_kick_enabled,
+                    "renewal_reminder_days": renewal_reminder_days,
+                    "should_show_renewal_reminder": bool(
+                        code_obj.has_warranty
+                        and is_valid
+                        and auto_kick_enabled
+                        and remaining_days is not None
+                        and remaining_days <= renewal_reminder_days
+                    ),
                 })
 
             # 3. 判断是否可以重复使用 (只要有有效的质保码且有被封的 Team)

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2407,6 +2407,24 @@ body.admin-theme .dropdown-menu {
     font-weight: 700;
 }
 
+.navbar-task-btn {
+    position: relative;
+}
+
+.navbar-task-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 20px;
+    height: 20px;
+    padding: 0 0.35rem;
+    border-radius: 999px;
+    background: var(--danger);
+    color: #fff;
+    font-size: 0.7rem;
+    font-weight: 700;
+}
+
 .main-container {
     width: 100%;
     max-width: none;

--- a/app/static/css/user.css
+++ b/app/static/css/user.css
@@ -934,6 +934,23 @@ body.redeem-page .btn-primary {
   border-top: 1px solid var(--border-base);
 }
 
+.renewal-reminder-footer {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+@media (max-width: 760px) {
+  .renewal-reminder-footer {
+    flex-direction: column;
+  }
+
+  .renewal-reminder-footer .btn {
+    width: 100%;
+  }
+}
+
 @media (max-width: 760px) {
   .announcement-dialog {
     width: min(680px, calc(100vw - 16px));

--- a/app/static/js/redeem.js
+++ b/app/static/js/redeem.js
@@ -20,6 +20,8 @@ let currentTopTab = 'redeem';
 let isRedeeming = false;
 let isCheckingWarranty = false;
 let lastAnnouncementTrigger = null;
+let lastRenewalReminderTrigger = null;
+let pendingRenewalReminderResolver = null;
 
 // Toast提示函数
 function showToast(message, type = 'info') {
@@ -425,32 +427,8 @@ function getFriendlyDeviceAuthErrorMessage(rawMessage, statusCode = 0) {
     return message;
 }
 
-function initAnnouncementModal() {
-    const announcement = window.REDEEM_ANNOUNCEMENT || {};
-    if (!announcement.enabled || !announcement.markdown || !String(announcement.markdown).trim()) {
-        return;
-    }
-
-    const modal = document.getElementById('announcementModal');
-    const content = document.getElementById('announcementContent');
-    const closeBtn = document.getElementById('announcementCloseBtn');
-    const confirmBtn = document.getElementById('announcementConfirmBtn');
-    const backdrop = document.getElementById('announcementBackdrop');
-    const dialog = modal?.querySelector('.announcement-dialog');
-
-    if (!modal || !content || !dialog) return;
-
+function bindDialogFocusTrap(modal, dialog, onClose, getLastTrigger) {
     const focusableSelector = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
-
-    const closeModal = () => {
-        modal.classList.remove('show');
-        modal.setAttribute('aria-hidden', 'true');
-        document.body.classList.remove('modal-open');
-        document.removeEventListener('keydown', handleKeydown);
-        if (lastAnnouncementTrigger && typeof lastAnnouncementTrigger.focus === 'function') {
-            lastAnnouncementTrigger.focus();
-        }
-    };
 
     const trapFocus = (event) => {
         if (event.key !== 'Tab') return;
@@ -472,17 +450,13 @@ function initAnnouncementModal() {
     const handleKeydown = (event) => {
         if (event.key === 'Escape') {
             event.preventDefault();
-            closeModal();
+            onClose();
             return;
         }
         trapFocus(event);
     };
 
-    content.innerHTML = renderMarkdownSafe(String(announcement.markdown));
-    lastAnnouncementTrigger = document.activeElement;
-    modal.classList.add('show');
-    modal.setAttribute('aria-hidden', 'false');
-    document.body.classList.add('modal-open');
+    modal._focusTrapHandler = handleKeydown;
     document.addEventListener('keydown', handleKeydown);
 
     const firstFocusable = dialog.querySelector(focusableSelector);
@@ -490,9 +464,93 @@ function initAnnouncementModal() {
         firstFocusable.focus();
     }
 
+    modal._restoreFocus = () => {
+        document.removeEventListener('keydown', handleKeydown);
+        const trigger = getLastTrigger();
+        if (trigger && typeof trigger.focus === 'function') {
+            trigger.focus();
+        }
+    };
+}
+
+function initAnnouncementModal() {
+    const announcement = window.REDEEM_ANNOUNCEMENT || {};
+    if (!announcement.enabled || !announcement.markdown || !String(announcement.markdown).trim()) {
+        return;
+    }
+
+    const modal = document.getElementById('announcementModal');
+    const content = document.getElementById('announcementContent');
+    const closeBtn = document.getElementById('announcementCloseBtn');
+    const confirmBtn = document.getElementById('announcementConfirmBtn');
+    const backdrop = document.getElementById('announcementBackdrop');
+    const dialog = modal?.querySelector('.announcement-dialog');
+
+    if (!modal || !content || !dialog) return;
+
+    const closeModal = () => {
+        modal.classList.remove('show');
+        modal.setAttribute('aria-hidden', 'true');
+        document.body.classList.remove('modal-open');
+        if (typeof modal._restoreFocus === 'function') {
+            modal._restoreFocus();
+        }
+    };
+
+    content.innerHTML = renderMarkdownSafe(String(announcement.markdown));
+    lastAnnouncementTrigger = document.activeElement;
+    modal.classList.add('show');
+    modal.setAttribute('aria-hidden', 'false');
+    document.body.classList.add('modal-open');
+    bindDialogFocusTrap(modal, dialog, closeModal, () => lastAnnouncementTrigger);
+
     if (closeBtn) closeBtn.addEventListener('click', closeModal);
     if (confirmBtn) confirmBtn.addEventListener('click', closeModal);
     if (backdrop) backdrop.addEventListener('click', closeModal);
+}
+
+function initRenewalReminderModal() {
+    const modal = document.getElementById('renewalReminderModal');
+    const closeBtn = document.getElementById('renewalReminderCloseBtn');
+    const cancelBtn = document.getElementById('renewalReminderCancelBtn');
+    const skipBtn = document.getElementById('renewalReminderSkipBtn');
+    const contactBtn = document.getElementById('renewalReminderContactBtn');
+    const backdrop = document.getElementById('renewalReminderBackdrop');
+    const dialog = modal?.querySelector('.announcement-dialog');
+    if (!modal || !dialog) return;
+
+    const resolveAndClose = (action) => {
+        modal.classList.remove('show');
+        modal.setAttribute('aria-hidden', 'true');
+        document.body.classList.remove('modal-open');
+        if (typeof modal._restoreFocus === 'function') {
+            modal._restoreFocus();
+        }
+        if (pendingRenewalReminderResolver) {
+            pendingRenewalReminderResolver(action);
+            pendingRenewalReminderResolver = null;
+        }
+    };
+
+    if (closeBtn) closeBtn.addEventListener('click', () => resolveAndClose('cancel'));
+    if (cancelBtn) cancelBtn.addEventListener('click', () => resolveAndClose('cancel'));
+    if (skipBtn) skipBtn.addEventListener('click', () => resolveAndClose('continue'));
+    if (contactBtn) contactBtn.addEventListener('click', () => resolveAndClose('contact'));
+    if (backdrop) backdrop.addEventListener('click', () => resolveAndClose('cancel'));
+
+    modal._open = (contentHtml) => {
+        const content = document.getElementById('renewalReminderContent');
+        if (!content) return Promise.resolve('continue');
+        content.innerHTML = contentHtml;
+        lastRenewalReminderTrigger = document.activeElement;
+        modal.classList.add('show');
+        modal.setAttribute('aria-hidden', 'false');
+        document.body.classList.add('modal-open');
+        bindDialogFocusTrap(modal, dialog, () => resolveAndClose('cancel'), () => lastRenewalReminderTrigger);
+        return new Promise((resolve) => {
+            pendingRenewalReminderResolver = resolve;
+        });
+    };
 }
 
 // 切换步骤
@@ -688,7 +746,14 @@ async function handleDynamicActionClick(event) {
             await oneClickReplace(
                 decodeActionValue(actionButton.dataset.code),
                 decodeActionValue(actionButton.dataset.email),
-                actionButton
+                actionButton,
+                {
+                    teamId: Number(actionButton.dataset.teamId || 0) || null,
+                    remainingWarrantyDays: actionButton.dataset.remainingWarrantyDays,
+                    autoKickEnabled: actionButton.dataset.autoKickEnabled === 'true',
+                    renewalReminderDays: actionButton.dataset.renewalReminderDays,
+                    shouldShowRenewalReminder: actionButton.dataset.showRenewalReminder === 'true',
+                }
             );
             break;
         case 'enable-device-auth':
@@ -754,6 +819,7 @@ document.addEventListener('DOMContentLoaded', () => {
     switchTopTab('redeem');
     setWarrantyResultVisible(false);
     initAnnouncementModal();
+    initRenewalReminderModal();
     window.addEventListener('resize', () => {
         const activeTab = document.querySelector('.top-tab.active');
         updateTabIndicator(activeTab);
@@ -1087,6 +1153,11 @@ function showWarrantyResult(data) {
                             data-action="one-click-replace"
                             data-code="${encodeActionValue(record.code || '')}"
                             data-email="${encodeActionValue(record.email || currentEmail || '')}"
+                            data-team-id="${Number(record.team_id || 0)}"
+                            data-remaining-warranty-days="${record.remaining_warranty_days ?? ''}"
+                            data-auto-kick-enabled="${record.auto_kick_enabled ? 'true' : 'false'}"
+                            data-renewal-reminder-days="${record.renewal_reminder_days ?? ''}"
+                            data-show-renewal-reminder="${record.should_show_renewal_reminder ? 'true' : 'false'}"
                         >
                             <i data-lucide="rotate-cw"></i> 一键换车
                         </button>
@@ -1162,8 +1233,71 @@ async function copyWarrantyCode(code) {
     }
 }
 
+async function submitRenewalRequest(email, code, teamId = null) {
+    const response = await fetch('/warranty/renewal-request', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+            email,
+            code,
+            team_id: teamId,
+            source: 'one_click_replace'
+        })
+    });
+
+    const { text, data } = await parseJsonResponse(response);
+    if (response.ok && data?.success) {
+        return data;
+    }
+
+    const rawError = (data?.detail ?? data?.error ?? data?.message ?? data?.reason) || text;
+    throw new Error(rawError || '提交续期请求失败');
+}
+
+async function maybeHandleRenewalReminder(code, email, btn, options = {}) {
+    const shouldShow = Boolean(options.shouldShowRenewalReminder);
+    if (!shouldShow || !options.autoKickEnabled) {
+        return true;
+    }
+
+    const modal = document.getElementById('renewalReminderModal');
+    if (!modal || typeof modal._open !== 'function') {
+        return true;
+    }
+
+    const remainingDaysRaw = options.remainingWarrantyDays;
+    const remainingDays = Number.isFinite(Number(remainingDaysRaw)) ? Number(remainingDaysRaw) : null;
+    const reminderDaysRaw = options.renewalReminderDays;
+    const reminderDays = Number.isFinite(Number(reminderDaysRaw)) ? Number(reminderDaysRaw) : null;
+
+    const messageHtml = `
+        <p>当前兑换码剩余 <strong>${escapeHtml(remainingDays ?? '-')}</strong> 天到期。</p>
+        <p>如果现在加入新的 Team，质保到期后系统会自动将您移出。</p>
+        <p>如需延长质保时间，可先联系管理员申请续期；也可以暂不续期，继续加入新的 Team。${reminderDays ? `（当前提醒阈值：${escapeHtml(reminderDays)} 天）` : ''}</p>
+    `;
+
+    const action = await modal._open(messageHtml);
+    if (action === 'cancel') {
+        return false;
+    }
+
+    if (action === 'contact') {
+        try {
+            const result = await submitRenewalRequest(email, code, options.teamId || null);
+            showToast(result.message || '已通知管理员处理续期请求', 'success');
+        } catch (error) {
+            showToast(error?.message || '提交续期请求失败，请稍后重试', 'error');
+            return false;
+        }
+    }
+
+    return true;
+}
+
 // 一键换车
-async function oneClickReplace(code, email, btn) {
+async function oneClickReplace(code, email, btn, options = {}) {
     if (!code || !email) {
         showToast('无法获取完整信息，请手动重试', 'error');
         return;
@@ -1184,9 +1318,13 @@ async function oneClickReplace(code, email, btn) {
         if (window.lucide) lucide.createIcons();
     }
 
-    showToast('正在为您尝试自动兑换...', 'info');
-
     try {
+        const canContinue = await maybeHandleRenewalReminder(code, email, btn, options);
+        if (!canContinue) {
+            return;
+        }
+
+        showToast('正在为您尝试自动兑换...', 'info');
         await confirmRedeem(null);
     } finally {
         if (btn && document.body.contains(btn)) {

--- a/app/templates/admin/renewal_requests/index.html
+++ b/app/templates/admin/renewal_requests/index.html
@@ -1,0 +1,263 @@
+{% extends "base.html" %}
+
+{% block title %}待处理任务 - GPT Team 管理系统{% endblock %}
+
+{% block content %}
+<div class="workspace-page records-workspace-page">
+    <div class="page-header">
+        <div class="page-header-copy">
+            <div class="page-header-kicker">
+                <i data-lucide="list-todo"></i>
+                <span>Pending Tasks</span>
+            </div>
+            <h2>待处理任务</h2>
+            <p>集中处理用户提交的质保续期请求，支持按单条输入续期天数后立即生效，或直接忽略。</p>
+            <div class="page-header-meta">
+                <span class="page-meta-pill"><i data-lucide="inbox"></i><span>{{ stats.total }} 条总任务</span></span>
+                <span class="page-meta-pill"><i data-lucide="clock-3"></i><span>待处理 {{ stats.pending }} 条</span></span>
+                <span class="page-meta-pill"><i data-lucide="badge-check"></i><span>已续期 {{ stats.extended }} 条</span></span>
+            </div>
+        </div>
+    </div>
+
+    <div class="stats-container">
+        <div class="stat-card">
+            <div class="stat-icon"><i data-lucide="inbox"></i></div>
+            <div class="stat-content">
+                <div class="stat-value">{{ stats.total }}</div>
+                <div class="stat-label">总任务数</div>
+            </div>
+        </div>
+        <div class="stat-card stat-warning">
+            <div class="stat-icon"><i data-lucide="clock-3"></i></div>
+            <div class="stat-content">
+                <div class="stat-value">{{ stats.pending }}</div>
+                <div class="stat-label">待处理</div>
+            </div>
+        </div>
+        <div class="stat-card stat-success">
+            <div class="stat-icon"><i data-lucide="badge-check"></i></div>
+            <div class="stat-content">
+                <div class="stat-value">{{ stats.extended }}</div>
+                <div class="stat-label">已续期</div>
+            </div>
+        </div>
+        <div class="stat-card stat-info">
+            <div class="stat-icon"><i data-lucide="circle-off"></i></div>
+            <div class="stat-content">
+                <div class="stat-value">{{ stats.ignored }}</div>
+                <div class="stat-label">已忽略</div>
+            </div>
+        </div>
+    </div>
+
+    <div class="workbench-panel">
+        <div class="content-section workbench-toolbar">
+            <div class="workbench-toolbar-row">
+                <div class="workbench-toolbar-copy">
+                    <h3>筛选条件</h3>
+                    <p>可按处理状态查看当前续期请求，待处理项会在顶部按钮和这里同步显示。</p>
+                </div>
+            </div>
+
+            <form method="get" action="/admin/renewal-requests" class="search-form-grid">
+                <div class="form-group">
+                    <label for="status_filter">处理状态</label>
+                    <select id="status_filter" name="status_filter" class="form-control">
+                        <option value="" {% if not status_filter %}selected{% endif %}>全部</option>
+                        <option value="pending" {% if status_filter == 'pending' %}selected{% endif %}>待处理</option>
+                        <option value="extended" {% if status_filter == 'extended' %}selected{% endif %}>已续期</option>
+                        <option value="ignored" {% if status_filter == 'ignored' %}selected{% endif %}>已忽略</option>
+                    </select>
+                </div>
+                <div class="form-actions" style="display: flex; gap: 0.5rem; align-items: end;">
+                    <button type="submit" class="btn btn-primary" style="flex: 1;">
+                        <i data-lucide="search"></i> 筛选
+                    </button>
+                    <a href="/admin/renewal-requests" class="btn btn-secondary">
+                        <i data-lucide="rotate-ccw"></i> 重置
+                    </a>
+                </div>
+            </form>
+        </div>
+
+        <div class="content-section workbench-table-card">
+            <div class="table-section-head">
+                <div class="table-section-copy">
+                    <h3>续期请求列表</h3>
+                    <p>输入续期天数后点击“续期”，会在当前剩余质保时间基础上直接增加对应天数并立即生效。</p>
+                </div>
+            </div>
+
+            {% if renewal_requests %}
+            <div class="table-container mobile-card-table-container">
+                <table class="data-table mobile-card-table">
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>用户邮箱</th>
+                            <th>兑换码</th>
+                            <th>剩余天数</th>
+                            <th>质保到期</th>
+                            <th>状态</th>
+                            <th>申请时间</th>
+                            <th style="text-align: right;">操作</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for item in renewal_requests %}
+                        <tr>
+                            <td data-label="ID"><span class="text-muted">{{ item.id }}</span></td>
+                            <td data-label="用户邮箱"><strong>{{ item.email }}</strong></td>
+                            <td data-label="兑换码"><code>{{ item.code }}</code></td>
+                            <td data-label="剩余天数">
+                                {% if item.remaining_warranty_days is not none %}
+                                <span class="badge badge-secondary">{{ item.remaining_warranty_days }} 天</span>
+                                {% else %}
+                                <span class="text-muted">-</span>
+                                {% endif %}
+                            </td>
+                            <td data-label="质保到期">{{ item.warranty_expires_at|format_datetime if item.warranty_expires_at else '-' }}</td>
+                            <td data-label="状态">
+                                {% if item.status == 'pending' %}
+                                <span class="status-badge status-warning">待处理</span>
+                                {% elif item.status == 'extended' %}
+                                <span class="status-badge status-active">已续期</span>
+                                {% else %}
+                                <span class="status-badge status-expired">已忽略</span>
+                                {% endif %}
+                            </td>
+                            <td data-label="申请时间">{{ item.requested_at|format_datetime if item.requested_at else '-' }}</td>
+                            <td class="table-actions-cell" data-label="操作" style="text-align: right;">
+                                {% if item.status == 'pending' %}
+                                <div class="action-buttons renewal-action-stack">
+                                    <input type="number" min="1" max="365" placeholder="续期天数" class="form-control renewal-days-input" id="renewalDays{{ item.id }}">
+                                    <div class="action-buttons" style="justify-content: flex-end;">
+                                        <button type="button" class="btn btn-sm btn-primary" onclick="extendRenewalRequest({{ item.id }}, this)">
+                                            <i data-lucide="calendar-plus-2"></i> 续期
+                                        </button>
+                                        <button type="button" class="btn btn-sm btn-secondary" onclick="ignoreRenewalRequest({{ item.id }}, this)">
+                                            <i data-lucide="circle-off"></i> 忽略
+                                        </button>
+                                    </div>
+                                </div>
+                                {% else %}
+                                <span class="text-muted">已处理</span>
+                                {% endif %}
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            {% else %}
+            <div class="workbench-empty-state">
+                <div class="empty-state">
+                    <i data-lucide="list-todo" style="width: 48px; height: 48px; margin-bottom: 1rem; opacity: 0.2;"></i>
+                    <p>当前没有符合条件的续期任务。</p>
+                </div>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_css %}
+<style>
+    .renewal-action-stack {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0.5rem;
+    }
+
+    .renewal-days-input {
+        min-width: 120px;
+    }
+</style>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+    async function extendRenewalRequest(requestId, btn) {
+        const daysInput = document.getElementById(`renewalDays${requestId}`);
+        const extension_days = parseInt(daysInput?.value || '0', 10);
+        if (!extension_days || extension_days < 1 || extension_days > 365) {
+            showToast('请输入 1~365 的续期天数', 'error');
+            return;
+        }
+
+        const originalContent = btn ? btn.innerHTML : '';
+        try {
+            if (btn) {
+                btn.disabled = true;
+                btn.innerHTML = '<i data-lucide="loader-2" class="spin" style="width: 14px; height: 14px;"></i> 处理中...';
+                lucide.createIcons();
+            }
+
+            const response = await fetch(`/admin/renewal-requests/${requestId}/extend`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ extension_days })
+            });
+            const result = await response.json();
+            if (result.success) {
+                showToast(result.message || '续期成功', 'success');
+                setTimeout(() => location.reload(), 800);
+                return;
+            }
+            showToast(result.error || '续期失败', 'error');
+        } catch (error) {
+            console.error('续期失败:', error);
+            showToast('请求失败，请稍后重试', 'error');
+        } finally {
+            if (btn && document.body.contains(btn)) {
+                btn.disabled = false;
+                btn.innerHTML = originalContent;
+                lucide.createIcons();
+            }
+        }
+    }
+
+    async function ignoreRenewalRequest(requestId, btn) {
+        if (!confirm('确定忽略这条续期请求吗？')) {
+            return;
+        }
+
+        const originalContent = btn ? btn.innerHTML : '';
+        try {
+            if (btn) {
+                btn.disabled = true;
+                btn.innerHTML = '<i data-lucide="loader-2" class="spin" style="width: 14px; height: 14px;"></i> 处理中...';
+                lucide.createIcons();
+            }
+
+            const response = await fetch(`/admin/renewal-requests/${requestId}/ignore`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({})
+            });
+            const result = await response.json();
+            if (result.success) {
+                showToast(result.message || '已忽略', 'success');
+                setTimeout(() => location.reload(), 800);
+                return;
+            }
+            showToast(result.error || '忽略失败', 'error');
+        } catch (error) {
+            console.error('忽略续期请求失败:', error);
+            showToast('请求失败，请稍后重试', 'error');
+        } finally {
+            if (btn && document.body.contains(btn)) {
+                btn.disabled = false;
+                btn.innerHTML = originalContent;
+                lucide.createIcons();
+            }
+        }
+    }
+</script>
+{% endblock %}

--- a/app/templates/admin/settings/index.html
+++ b/app/templates/admin/settings/index.html
@@ -217,6 +217,13 @@
             <p class="form-help">建议 6~24 小时。该任务会按当前后台选择的质保计算方式重新判断历史质保码是否过保。</p>
         </div>
 
+        <div class="form-group">
+            <label for="warrantyRenewalReminderDays">续期提醒设置 (天)</label>
+            <input type="number" id="warrantyRenewalReminderDays" name="renewal_reminder_days"
+                value="{{ warranty_renewal_reminder_days or '7' }}" min="1" max="30" class="form-control">
+            <p class="form-help">仅在启用自动踢人后生效。当质保码剩余天数小于等于该值且用户准备换到新 Team 时，前台会弹出续期提醒。</p>
+        </div>
+
         <p class="form-help">该操作不可恢复，请确认售后流程允许系统自动清退成员并销毁兑换码后再开启。</p>
         <button type="submit" class="btn btn-primary">保存自动踢人配置</button>
     </form>
@@ -609,9 +616,15 @@
 
         const enabled = document.getElementById('warrantyAutoKickEnabled').checked;
         const interval_hours = parseInt(document.getElementById('warrantyAutoKickInterval').value);
+        const renewal_reminder_days = parseInt(document.getElementById('warrantyRenewalReminderDays').value);
 
         if (isNaN(interval_hours) || interval_hours < 1 || interval_hours > 168) {
             showToast('检查间隔必须在 1~168 小时之间', 'error');
+            return;
+        }
+
+        if (isNaN(renewal_reminder_days) || renewal_reminder_days < 1 || renewal_reminder_days > 30) {
+            showToast('续期提醒天数必须在 1~30 天之间', 'error');
             return;
         }
 
@@ -621,7 +634,7 @@
                 headers: {
                     'Content-Type': 'application/json'
                 },
-                body: JSON.stringify({ enabled, interval_hours })
+                body: JSON.stringify({ enabled, interval_hours, renewal_reminder_days })
             });
 
             const data = await response.json();

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -66,6 +66,10 @@
                         <i data-lucide="file-text"></i>
                         <span>使用记录</span>
                     </a>
+                    <a href="/admin/renewal-requests" class="desktop-nav-link {% if active_page == 'renewal_requests' %}active{% endif %}">
+                        <i data-lucide="list-todo"></i>
+                        <span>待处理任务</span>
+                    </a>
                     <a href="/admin/settings" class="desktop-nav-link {% if system_active %}active{% endif %}">
                         <i data-lucide="settings-2"></i>
                         <span>系统中心</span>
@@ -75,6 +79,13 @@
 
             <div class="navbar-menu">
                 <span class="navbar-user">运营后台</span>
+                <a href="/admin/renewal-requests" class="btn btn-secondary navbar-task-btn {% if active_page == 'renewal_requests' %}active{% endif %}">
+                    <i data-lucide="list-todo" style="width: 15px; height: 15px;"></i>
+                    <span>待处理任务</span>
+                    {% if pending_renewal_request_count %}
+                    <span class="navbar-task-badge">{{ pending_renewal_request_count }}</span>
+                    {% endif %}
+                </a>
                 <button type="button" class="btn btn-secondary" id="openThemeSwitcherBtn">
                     <i data-lucide="palette" style="width: 15px; height: 15px;"></i> 冷调
                 </button>
@@ -125,6 +136,12 @@
                     <a href="/admin/settings">
                         <span class="menu-icon" data-lucide="settings-2"></span>
                         <span class="menu-text">系统中心</span>
+                    </a>
+                </li>
+                <li class="menu-item {% if active_page == 'renewal_requests' %}active{% endif %}">
+                    <a href="/admin/renewal-requests">
+                        <span class="menu-icon" data-lucide="list-todo"></span>
+                        <span class="menu-text">待处理任务{% if pending_renewal_request_count %} ({{ pending_renewal_request_count }}){% endif %}</span>
                     </a>
                 </li>
             </ul>

--- a/app/templates/user/redeem.html
+++ b/app/templates/user/redeem.html
@@ -165,6 +165,24 @@
         </div>
     </div>
 
+    <div id="renewalReminderModal" class="announcement-modal" aria-hidden="true">
+        <div class="announcement-backdrop" id="renewalReminderBackdrop"></div>
+        <div class="announcement-dialog" role="dialog" aria-modal="true" aria-labelledby="renewalReminderTitle">
+            <div class="announcement-header">
+                <h3 id="renewalReminderTitle"><i data-lucide="calendar-clock"></i> 质保即将到期</h3>
+                <button type="button" class="announcement-close" id="renewalReminderCloseBtn" aria-label="关闭提醒">
+                    <i data-lucide="x"></i>
+                </button>
+            </div>
+            <div class="announcement-body" id="renewalReminderContent"></div>
+            <div class="announcement-footer renewal-reminder-footer">
+                <button type="button" class="btn btn-secondary" id="renewalReminderCancelBtn">取消</button>
+                <button type="button" class="btn btn-secondary" id="renewalReminderSkipBtn">暂不续期，继续加入</button>
+                <button type="button" class="btn btn-primary" id="renewalReminderContactBtn">联系管理员续期</button>
+            </div>
+        </div>
+    </div>
+
     <script>
         window.REDEEM_ANNOUNCEMENT = {
             enabled: {{ announcement_enabled|tojson }},

--- a/init_db.py
+++ b/init_db.py
@@ -74,6 +74,11 @@ async def create_default_settings():
                 value="12",
                 description="质保过期自动踢人检查间隔（小时）"
             ),
+            Setting(
+                key="warranty_renewal_reminder_days",
+                value="7",
+                description="距离质保结束多少天内提醒用户联系管理员续期"
+            ),
         ]
 
         session.add_all(default_settings)

--- a/tests/test_redeem_flow.py
+++ b/tests/test_redeem_flow.py
@@ -9,7 +9,7 @@ from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.database import Base
-from app.models import RedemptionCode, RedemptionRecord, Team, TeamEmailMapping, Setting
+from app.models import RedemptionCode, RedemptionRecord, RenewalRequest, Team, TeamEmailMapping, Setting
 from app.services.redeem_flow import RedeemFlowService
 from app.services.notification import notification_service
 from app.services.redemption import RedemptionService
@@ -286,6 +286,111 @@ class WarrantyAutoKickTests(unittest.IsolatedAsyncioTestCase):
                 select(RedemptionRecord).where(RedemptionRecord.code == "WARRANTY-KICK-001")
             )
             self.assertEqual(list(remaining_records.scalars().all()), [])
+
+    async def test_extension_days_prevent_auto_kick_until_extended_expiry(self):
+        async with self.session_factory() as session:
+            team = Team(
+                id=202,
+                email="owner@example.com",
+                access_token_encrypted="token-1",
+                account_id="acct-auto-kick-keep",
+                team_name="Extended Team",
+                current_members=1,
+                max_members=5,
+                status="active",
+                pool_type="normal",
+            )
+            session.add(team)
+            await session.commit()
+
+            code = RedemptionCode(
+                code="WARRANTY-EXTEND-001",
+                status="used",
+                has_warranty=True,
+                warranty_days=30,
+                extension_days=10,
+                used_by_email="extend@example.com",
+                used_team_id=202,
+                used_at=get_now() - timedelta(days=35),
+                warranty_expires_at=get_now() + timedelta(days=5),
+            )
+            session.add_all([
+                code,
+                Setting(key="warranty_expiration_mode", value="refresh_on_redeem"),
+            ])
+            await session.commit()
+
+            service = WarrantyService()
+            result = await service.scan_expired_warranty_codes(session)
+            self.assertTrue(result["success"])
+            self.assertEqual(result["total"], 0)
+
+    async def test_create_and_extend_renewal_request_updates_expiry(self):
+        async with self.session_factory() as session:
+            team = Team(
+                id=301,
+                email="owner@example.com",
+                access_token_encrypted="token-1",
+                account_id="acct-renew-request",
+                team_name="Renew Request Team",
+                current_members=1,
+                max_members=5,
+                status="active",
+                pool_type="normal",
+            )
+            session.add(team)
+            await session.commit()
+
+            code = RedemptionCode(
+                code="WARRANTY-REQUEST-001",
+                status="used",
+                has_warranty=True,
+                warranty_days=30,
+                extension_days=0,
+                used_by_email="request@example.com",
+                used_team_id=301,
+                used_at=get_now() - timedelta(days=27),
+                warranty_expires_at=get_now() + timedelta(days=3),
+            )
+            session.add_all([
+                code,
+                Setting(key="warranty_expiration_mode", value="refresh_on_redeem"),
+            ])
+            await session.commit()
+
+            service = WarrantyService()
+            create_result = await service.create_renewal_request(
+                session,
+                email="request@example.com",
+                code="WARRANTY-REQUEST-001",
+                team_id=301,
+            )
+            self.assertTrue(create_result["success"])
+
+            list_result = await service.get_renewal_requests(session, status_filter="pending")
+            self.assertEqual(list_result["pending_count"], 1)
+            request_id = list_result["requests"][0]["id"]
+
+            extend_result = await service.extend_warranty_request(
+                session,
+                request_id=request_id,
+                extension_days=7,
+            )
+            self.assertTrue(extend_result["success"])
+            self.assertEqual(extend_result["remaining_warranty_days"], 10)
+
+            updated_code = await session.execute(
+                select(RedemptionCode).where(RedemptionCode.code == "WARRANTY-REQUEST-001")
+            )
+            updated_code_obj = updated_code.scalar_one()
+            self.assertEqual(updated_code_obj.extension_days, 7)
+
+            updated_request = await session.execute(
+                select(RenewalRequest).where(RenewalRequest.id == request_id)
+            )
+            updated_request_obj = updated_request.scalar_one()
+            self.assertEqual(updated_request_obj.status, "extended")
+            self.assertEqual(updated_request_obj.extension_days, 7)
 
 
 class TeamServiceBulkInviteTests(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
Add renewal reminder prompts for near-expiry warranty redemptions, a pending task queue for admin handling, and direct warranty extensions that update expiry calculations before auto-kick runs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lolollipop/team-manage-refresh/pull/176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
