### PR TITLE
fix(warranty): refine renewal task and reminder defaults

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -2408,7 +2408,7 @@ async def update_announcement(
 @router.get("/renewal-requests", response_class=HTMLResponse)
 async def renewal_requests_page(
     request: Request,
-    status_filter: Optional[str] = None,
+    status_filter: Optional[str] = "pending",
     db: AsyncSession = Depends(get_db),
     current_user: dict = Depends(require_admin)
 ):

--- a/app/templates/admin/renewal_requests/index.html
+++ b/app/templates/admin/renewal_requests/index.html
@@ -56,7 +56,7 @@
             <div class="workbench-toolbar-row">
                 <div class="workbench-toolbar-copy">
                     <h3>筛选条件</h3>
-                    <p>可按处理状态查看当前续期请求，待处理项会在顶部按钮和这里同步显示。</p>
+                    <p>默认只展示待处理任务；处理完成后会自动从当前列表中移除，避免长期占空间。</p>
                 </div>
             </div>
 

--- a/app/templates/admin/settings/index.html
+++ b/app/templates/admin/settings/index.html
@@ -220,7 +220,8 @@
         <div class="form-group">
             <label for="warrantyRenewalReminderDays">续期提醒设置 (天)</label>
             <input type="number" id="warrantyRenewalReminderDays" name="renewal_reminder_days"
-                value="{{ warranty_renewal_reminder_days or '7' }}" min="1" max="30" class="form-control">
+                value="{{ warranty_renewal_reminder_days or '7' }}" min="1" max="30" class="form-control"
+                {% if (warranty_auto_kick_enabled or 'false')|lower not in ['1','true','yes','on'] %}disabled{% endif %}>
             <p class="form-help">仅在启用自动踢人后生效。当质保码剩余天数小于等于该值且用户准备换到新 Team 时，前台会弹出续期提醒。</p>
         </div>
 
@@ -609,6 +610,17 @@
             showToast('网络错误', 'error');
         }
     });
+
+    const warrantyAutoKickEnabledInput = document.getElementById('warrantyAutoKickEnabled');
+    const warrantyRenewalReminderDaysInput = document.getElementById('warrantyRenewalReminderDays');
+    const syncWarrantyRenewalReminderState = () => {
+        if (!warrantyAutoKickEnabledInput || !warrantyRenewalReminderDaysInput) return;
+        warrantyRenewalReminderDaysInput.disabled = !warrantyAutoKickEnabledInput.checked;
+    };
+    if (warrantyAutoKickEnabledInput) {
+        warrantyAutoKickEnabledInput.addEventListener('change', syncWarrantyRenewalReminderState);
+        syncWarrantyRenewalReminderState();
+    }
 
     // 自动踢人配置表单
     document.getElementById('warrantyAutoKickForm').addEventListener('submit', async (e) => {


### PR DESCRIPTION
Keep the pending task entry visible at all times, default the renewal task page to pending items, and disable reminder settings unless auto-kick is enabled.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lolollipop/team-manage-refresh/pull/177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
