### PR TITLE
feat(team): route warranty codes to dedicated seats

### DIFF
--- a/app/db_migrations.py
+++ b/app/db_migrations.py
@@ -127,6 +127,11 @@ def run_auto_migration():
             cursor.execute("ALTER TABLE teams ADD COLUMN pool_type VARCHAR(20) DEFAULT 'normal'")
             migrations_applied.append("teams.pool_type")
 
+        if not column_exists(cursor, "teams", "warranty_seat_enabled"):
+            logger.info("添加 teams.warranty_seat_enabled 字段")
+            cursor.execute("ALTER TABLE teams ADD COLUMN warranty_seat_enabled BOOLEAN DEFAULT 0")
+            migrations_applied.append("teams.warranty_seat_enabled")
+
         if not column_exists(cursor, "redemption_codes", "pool_type"):
             logger.info("添加 redemption_codes.pool_type 字段")
             cursor.execute("ALTER TABLE redemption_codes ADD COLUMN pool_type VARCHAR(20) DEFAULT 'normal'")

--- a/app/models.py
+++ b/app/models.py
@@ -31,6 +31,7 @@ class Team(Base):
     status = Column(String(20), default="active", comment="状态: active/full/expired/error/banned")
     account_role = Column(String(50), comment="账号角色: account-owner/standard-user 等")
     device_code_auth_enabled = Column(Boolean, default=False, comment="是否开启设备代码身份验证")
+    warranty_seat_enabled = Column(Boolean, default=False, comment="是否作为质保兑换码分流目标 Team")
     error_count = Column(Integer, default=0, comment="连续报错次数")
     last_sync = Column(DateTime, comment="最后同步时间")
     created_at = Column(DateTime, default=get_now, comment="创建时间")

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -165,6 +165,11 @@ class TeamUpdateRequest(BaseModel):
     status: Optional[str] = Field(None, description="状态: active/full/expired/error/banned")
 
 
+class WarrantySeatToggleRequest(BaseModel):
+    """Team 质保车位开关请求"""
+    enabled: bool = Field(..., description="是否开启质保车位")
+
+
 class CodeUpdateRequest(BaseModel):
     """兑换码更新请求"""
     has_warranty: bool = Field(..., description="是否为质保兑换码")
@@ -536,6 +541,32 @@ async def update_team(
         )
 
 
+@router.post("/teams/{team_id}/warranty-seat")
+async def toggle_team_warranty_seat(
+    team_id: int,
+    payload: WarrantySeatToggleRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: dict = Depends(require_admin)
+):
+    """切换 Team 质保车位开关。"""
+    try:
+        result = await team_service.set_warranty_seat_enabled(
+            team_id=team_id,
+            enabled=payload.enabled,
+            db_session=db,
+        )
+        if not result["success"]:
+            return JSONResponse(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                content=result,
+            )
+        return JSONResponse(content=result)
+    except Exception:
+        logger.exception("更新 Team 质保车位开关失败")
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content={"success": False, "error": "操作失败，请稍后重试"}
+        )
 
 
 @router.post("/teams/import")
@@ -1320,7 +1351,7 @@ async def batch_refresh_teams(
 
                 try:
                     async with AsyncSessionLocal() as db_session:
-                        result = await team_service.sync_team_info(team_id, db_session, force_refresh=True)
+                        result = await team_service.sync_team_info(team_id, db_session, force_refresh=False)
                     item_success = bool(result.get("success"))
                     item_message = result.get("message")
                     item_error = result.get("error")

--- a/app/routes/redeem.py
+++ b/app/routes/redeem.py
@@ -138,7 +138,7 @@ async def confirm_redeem(
         if not result["success"]:
             # 根据错误类型返回不同的状态码
             error_msg = result.get("error") or "未知原因"
-            if any(kw in error_msg for kw in ["不存在", "已使用", "已过期", "截止时间", "已满", "席位", "质保", "无效", "失效", "maximum number of seats", "当前兑换码不会被消耗", "请选择其他 Team", "已加入所有可用 Team", "没有新的可用 Team"]):
+            if any(kw in error_msg for kw in ["不存在", "已使用", "已过期", "截止时间", "已满", "席位", "质保", "无效", "失效", "maximum number of seats", "当前兑换码不会被消耗", "请选择其他 Team", "已加入所有可用 Team", "没有新的可用 Team", "仅可加入"]):
                 status_code = status.HTTP_400_BAD_REQUEST
                 if any(kw in error_msg for kw in ["已满", "席位", "maximum number of seats", "当前兑换码不会被消耗", "请选择其他 Team", "已加入所有可用 Team", "没有新的可用 Team"]):
                     status_code = status.HTTP_409_CONFLICT

--- a/app/services/redeem_flow.py
+++ b/app/services/redeem_flow.py
@@ -99,6 +99,20 @@ class RedeemFlowService:
         self.team_service = TeamService()
         self.chatgpt_service = chatgpt_service
 
+    @staticmethod
+    def _resolve_warranty_requirement(code_meta: Dict[str, Any]) -> Optional[bool]:
+        if code_meta.get("virtual_welfare_code"):
+            return None
+        return bool(code_meta.get("has_warranty"))
+
+    @staticmethod
+    def _get_team_mode_label(warranty_required: Optional[bool]) -> str:
+        if warranty_required is True:
+            return "质保 Team"
+        if warranty_required is False:
+            return "非质保 Team"
+        return "Team"
+
     async def verify_code_and_get_teams(
         self,
         code: str,
@@ -140,6 +154,7 @@ class RedeemFlowService:
             # 2. 获取可用 Team 列表
             code_meta = validate_result.get("redemption_code") or {}
             pool_type = code_meta.get("pool_type", "normal")
+            warranty_required = self._resolve_warranty_requirement(code_meta)
             teams: List[Dict[str, Any]] = []
             if code_meta.get("virtual_welfare_code"):
                 bound_team_id = int(code_meta.get("team_id") or 0)
@@ -184,7 +199,11 @@ class RedeemFlowService:
                     "subscription_plan": bound_team.get("subscription_plan"),
                 }]
             else:
-                teams_result = await self.team_service.get_available_teams(db_session, pool_type=pool_type)
+                teams_result = await self.team_service.get_available_teams(
+                    db_session,
+                    pool_type=pool_type,
+                    warranty_required=warranty_required,
+                )
 
                 if not teams_result["success"]:
                     return {
@@ -222,7 +241,8 @@ class RedeemFlowService:
         db_session: AsyncSession,
         email: Optional[str] = None,
         exclude_team_ids: Optional[List[int]] = None,
-        pool_type: str = "normal"
+        pool_type: str = "normal",
+        warranty_required: Optional[bool] = None,
     ) -> Dict[str, Any]:
         """
         自动选择一个可用的 Team。
@@ -242,11 +262,13 @@ class RedeemFlowService:
                 excluded_ids.update(mapped_team_ids)
 
             # 查找所有 active 且未满的 Team
-            stmt = select(Team).where(
+            conditions = [
                 Team.status == "active",
                 Team.current_members < Team.max_members,
-                Team.pool_type == pool_type
-            )
+                Team.pool_type == pool_type,
+            ]
+            self.team_service._append_warranty_seat_condition(conditions, warranty_required)
+            stmt = select(Team).where(*conditions)
 
             if excluded_ids:
                 stmt = stmt.where(Team.id.not_in(sorted(excluded_ids)))
@@ -258,11 +280,12 @@ class RedeemFlowService:
             team = result.scalars().first()
 
             if not team:
-                reason = "没有可用的 Team"
+                team_mode_label = self._get_team_mode_label(warranty_required)
+                reason = f"没有可用的{team_mode_label}"
                 if mapped_team_ids:
-                    reason = "没有新的可用 Team；您已加入所有当前有席位的 Team，当前兑换码不会被消耗"
+                    reason = f"没有新的可用{team_mode_label}；您已加入所有当前有席位的{team_mode_label}，当前兑换码不会被消耗"
                 elif exclude_team_ids:
-                    reason = "您已加入所有可用 Team"
+                    reason = f"您已加入所有可用{team_mode_label}"
                 return {
                     "success": False,
                     "team_id": None,
@@ -325,6 +348,7 @@ class RedeemFlowService:
                         return {"success": False, "error": validate_result.get("reason") or "兑换码无效"}
                     code_meta = validate_result.get("redemption_code") or {}
                     pool_type = code_meta.get("pool_type", "normal")
+                    warranty_required = self._resolve_warranty_requirement(code_meta)
                     is_virtual_welfare_code = bool(code_meta.get("virtual_welfare_code"))
                     bound_welfare_team_id = int(code_meta.get("team_id") or 0) if is_virtual_welfare_code else 0
 
@@ -361,7 +385,8 @@ class RedeemFlowService:
                                 db_session,
                                 email=email,
                                 exclude_team_ids=sorted(excluded_team_ids) if excluded_team_ids else None,
-                                pool_type=pool_type
+                                pool_type=pool_type,
+                                warranty_required=warranty_required,
                             )
                             if not select_res["success"]:
                                 return {"success": False, "error": select_res["error"]}
@@ -412,6 +437,7 @@ class RedeemFlowService:
                                 team_id=team_id_final,
                                 db_session=db_session,
                                 pool_type=pool_type,
+                                warranty_required=warranty_required,
                             )
                             if not reserve_result["success"]:
                                 raise Exception(reserve_result["error"])

--- a/app/services/team.py
+++ b/app/services/team.py
@@ -36,6 +36,12 @@ class TeamService:
     """Team 管理服务类"""
 
     PROACTIVE_REFRESH_WINDOW_HOURS = 2
+
+    @staticmethod
+    def _append_warranty_seat_condition(conditions: List[Any], warranty_required: Optional[bool]) -> None:
+        if warranty_required is None:
+            return
+        conditions.append(Team.warranty_seat_enabled.is_(bool(warranty_required)))
     PLACEHOLDER_ACCOUNT_IDS = {"default", "personal", "none", "null", "me", "self"}
 
     def __init__(self):
@@ -142,7 +148,8 @@ class TeamService:
         self,
         team_id: int,
         db_session: AsyncSession,
-        pool_type: str = "normal"
+        pool_type: str = "normal",
+        warranty_required: Optional[bool] = None,
     ) -> Dict[str, Any]:
         """
         以数据库原子更新的方式预留一个席位。
@@ -150,15 +157,17 @@ class TeamService:
         这样即使在多 worker / 多实例环境中，也不会仅依赖进程内锁导致超拉。
         """
         current_time = get_now()
+        reserve_conditions = [
+            Team.id == team_id,
+            Team.pool_type == pool_type,
+            Team.status == "active",
+            Team.current_members < Team.max_members,
+            or_(Team.expires_at.is_(None), Team.expires_at >= current_time),
+        ]
+        self._append_warranty_seat_condition(reserve_conditions, warranty_required)
         reserve_stmt = (
             update(Team)
-            .where(
-                Team.id == team_id,
-                Team.pool_type == pool_type,
-                Team.status == "active",
-                Team.current_members < Team.max_members,
-                or_(Team.expires_at.is_(None), Team.expires_at >= current_time),
-            )
+            .where(*reserve_conditions)
             .values(
                 current_members=Team.current_members + 1,
                 status=case(
@@ -174,6 +183,9 @@ class TeamService:
                 return {"success": False, "error": f"目标 Team {team_id} 不存在"}
             if team.pool_type != pool_type:
                 return {"success": False, "error": f"目标 Team {team_id} 不属于当前兑换池"}
+            if warranty_required is not None and team.warranty_seat_enabled != bool(warranty_required):
+                mode_label = "已开启质保的 Team" if warranty_required else "未开启质保的 Team"
+                return {"success": False, "error": f"当前兑换码仅可加入{mode_label}"}
             if team.expires_at and team.expires_at < current_time:
                 team.status = "expired"
                 await db_session.flush()
@@ -2458,6 +2470,15 @@ class TeamService:
                     "Team 已满,无法添加成员",
                 )
 
+            mapping_result = await db_session.execute(
+                select(TeamEmailMapping.status).where(
+                    TeamEmailMapping.team_id == team_id,
+                    TeamEmailMapping.email == normalized_email,
+                )
+            )
+            existing_mapping_status = mapping_result.scalar_one_or_none()
+            had_active_mapping = existing_mapping_status in ACTIVE_TEAM_EMAIL_STATUSES
+
             # 4. 调用 ChatGPT API 发送邀请
             invite_result = await self.chatgpt_service.send_invite(
                 access_token,
@@ -2508,6 +2529,14 @@ class TeamService:
                 source="admin_add",
                 is_admin_invited=True,
             )
+            if not had_active_mapping:
+                team.current_members = min(team.current_members + 1, team.max_members)
+                if team.expires_at and team.expires_at < get_now():
+                    team.status = "expired"
+                elif team.current_members >= team.max_members:
+                    team.status = "full"
+                else:
+                    team.status = "active"
             await db_session.commit()
 
             logger.info(f"添加成员成功: {normalized_email} -> Team {team_id}")
@@ -2934,10 +2963,35 @@ class TeamService:
             logger.exception("开启设备身份验证失败")
             return {"success": False, "error": "开启设备身份验证失败，请稍后重试"}
 
+    async def set_warranty_seat_enabled(
+        self,
+        team_id: int,
+        enabled: bool,
+        db_session: AsyncSession,
+    ) -> Dict[str, Any]:
+        try:
+            team = await db_session.get(Team, team_id)
+            if not team:
+                return {"success": False, "error": f"Team ID {team_id} 不存在"}
+
+            team.warranty_seat_enabled = bool(enabled)
+            await db_session.commit()
+            return {
+                "success": True,
+                "enabled": team.warranty_seat_enabled,
+                "message": "质保车位已开启" if team.warranty_seat_enabled else "质保车位已关闭",
+                "error": None,
+            }
+        except Exception:
+            await db_session.rollback()
+            logger.exception("更新 Team 质保车位开关失败")
+            return {"success": False, "error": "更新质保车位失败，请稍后重试"}
+
     async def get_available_teams(
         self,
         db_session: AsyncSession,
-        pool_type: str = "normal"
+        pool_type: str = "normal",
+        warranty_required: Optional[bool] = None,
     ) -> Dict[str, Any]:
         """
         获取可用的 Team 列表 (用于用户兑换页面)
@@ -2950,11 +3004,13 @@ class TeamService:
         """
         try:
             # 查询 status='active' 且 current_members < max_members 的 Team
-            stmt = select(Team).where(
+            conditions = [
                 Team.status == "active",
                 Team.current_members < Team.max_members,
-                Team.pool_type == pool_type
-            )
+                Team.pool_type == pool_type,
+            ]
+            self._append_warranty_seat_condition(conditions, warranty_required)
+            stmt = select(Team).where(*conditions)
             result = await db_session.execute(stmt)
             teams = result.scalars().all()
 
@@ -3065,6 +3121,7 @@ class TeamService:
                 "status": team.status,
                 "account_role": team.account_role,
                 "device_code_auth_enabled": team.device_code_auth_enabled,
+                "warranty_seat_enabled": team.warranty_seat_enabled,
                 "last_sync": team.last_sync.isoformat() if team.last_sync else None,
                 "created_at": team.created_at.isoformat() if team.created_at else None
             }
@@ -3177,6 +3234,7 @@ class TeamService:
                     "max_members": team.max_members,
                     "status": team.status,
                     "device_code_auth_enabled": getattr(team, 'device_code_auth_enabled', False),
+                    "warranty_seat_enabled": getattr(team, "warranty_seat_enabled", False),
                     "last_sync": team.last_sync.isoformat() if team.last_sync else None,
                     "created_at": team.created_at.isoformat() if team.created_at else None,
                     "pool_type": getattr(team, "pool_type", "normal")

--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -979,6 +979,16 @@
                             <i data-lucide="refresh-cw" style="width: 16px; height: 16px;"></i>
                             <span class="btn-icon-fallback" aria-hidden="true">刷</span>
                         </button>
+                        {% if team.pool_type == 'normal' %}
+                        <button class="btn btn-sm btn-icon btn-minimal {{ 'btn-success' if team.warranty_seat_enabled else 'btn-secondary' }} btn-toggle-warranty-seat"
+                            data-id="{{ team.id }}"
+                            data-enabled="{{ 'true' if team.warranty_seat_enabled else 'false' }}"
+                            title="{{ '关闭质保' if team.warranty_seat_enabled else '开启质保' }}"
+                            aria-label="{{ '关闭质保' if team.warranty_seat_enabled else '开启质保' }}">
+                            <i data-lucide="shield" style="width: 16px; height: 16px;"></i>
+                            <span class="btn-icon-fallback" aria-hidden="true">保</span>
+                        </button>
+                        {% endif %}
                         <button class="btn btn-sm btn-icon btn-minimal btn-success btn-enable-device-auth"
                             data-id="{{ team.id }}" title="一键开启设备代码验证" aria-label="开启设备验证">
                             <i data-lucide="shield-check" style="width: 16px; height: 16px;"></i>
@@ -1305,6 +1315,14 @@
             });
         });
 
+        document.querySelectorAll('.btn-toggle-warranty-seat').forEach(btn => {
+            btn.addEventListener('click', () => {
+                const id = btn.getAttribute('data-id');
+                const enabled = btn.getAttribute('data-enabled') === 'true';
+                toggleTeamWarrantySeat(id, enabled);
+            });
+        });
+
         document.querySelectorAll('.btn-push-cliproxyapi').forEach(btn => {
             btn.addEventListener('click', () => {
                 const id = btn.getAttribute('data-id');
@@ -1357,6 +1375,35 @@
                 setTimeout(() => location.reload(), 1000);
             } else {
                 showToast(data.error || '开启失败', 'error');
+            }
+        } catch (error) {
+            showToast('网络错误', 'error');
+        }
+    }
+
+    async function toggleTeamWarrantySeat(teamId, currentlyEnabled) {
+        const nextEnabled = !currentlyEnabled;
+        const actionLabel = nextEnabled ? '开启' : '关闭';
+        if (!confirm(`确定要为该 Team ${actionLabel}质保车位吗？\n\n此操作仅影响后续兑换码分流，不会影响现有成员。`)) {
+            return;
+        }
+
+        try {
+            showToast(`正在${actionLabel}质保车位...`, 'info');
+            const response = await fetch(`/admin/teams/${teamId}/warranty-seat`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ enabled: nextEnabled })
+            });
+
+            const data = await response.json();
+            if (response.ok && data.success) {
+                showToast(data.message || `${actionLabel}成功`, 'success');
+                setTimeout(() => location.reload(), 1000);
+            } else {
+                showToast(data.error || `${actionLabel}失败`, 'error');
             }
         } catch (error) {
             showToast('网络错误', 'error');

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -764,6 +764,7 @@ eyJ..."></textarea>
                         <div class="form-group" id="single-warranty-days-group" style="display: none;">
                             <label>质保时长 (天) *</label>
                             <input type="number" name="warrantyDays" class="form-control" value="30" min="1" max="3650">
+                            <small class="form-text" style="display: block; margin-top: 8px; color: var(--warning, #c96a28);">已开启质保兑换码。请先在目标 Team 上开启质保车位模式，否则该兑换码将无法加入质保车位。</small>
                         </div>
                         <button type="submit" class="btn btn-primary">生成兑换码</button>
                     </form>
@@ -799,6 +800,7 @@ eyJ..."></textarea>
                         <div class="form-group" id="batch-warranty-days-group" style="display: none;">
                             <label>质保时长 (天) *</label>
                             <input type="number" name="warrantyDays" class="form-control" value="30" min="1" max="3650">
+                            <small class="form-text" style="display: block; margin-top: 8px; color: var(--warning, #c96a28);">已开启质保兑换码。请先在目标 Team 上开启质保车位模式，否则该兑换码将无法加入质保车位。</small>
                         </div>
                         <button type="submit" class="btn btn-primary">批量生成</button>
                     </form>

--- a/tests/test_admin_batch_refresh.py
+++ b/tests/test_admin_batch_refresh.py
@@ -1,0 +1,53 @@
+import json
+import unittest
+from unittest.mock import patch
+
+from fastapi.responses import StreamingResponse
+
+from app.routes import admin
+
+
+class _FakeSessionContext:
+    async def __aenter__(self):
+        return object()
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def _fake_async_session_local():
+    return _FakeSessionContext()
+
+
+class AdminBatchRefreshTests(unittest.IsolatedAsyncioTestCase):
+    async def test_batch_refresh_uses_non_force_sync_like_single_refresh(self):
+        calls = []
+
+        async def stub_sync(team_id, db_session, force_refresh=False):
+            calls.append((team_id, force_refresh))
+            return {
+                "success": True,
+                "message": f"同步成功 {team_id}",
+                "error": None,
+            }
+
+        with patch("app.routes.admin.AsyncSessionLocal", new=_fake_async_session_local), \
+             patch.object(admin.team_service, "sync_team_info", new=stub_sync):
+            response = await admin.batch_refresh_teams(
+                admin.BatchRefreshRequest(ids=[11, 22]),
+                current_user={"username": "admin", "is_admin": True},
+            )
+
+            self.assertIsInstance(response, StreamingResponse)
+
+            chunks = []
+            async for chunk in response.body_iterator:
+                if isinstance(chunk, (bytes, bytearray)):
+                    chunks.append(chunk.decode("utf-8"))
+                else:
+                    chunks.append(str(chunk))
+
+        payloads = [json.loads(line) for line in "".join(chunks).splitlines() if line.strip()]
+        self.assertEqual(payloads[-1]["type"], "finish")
+        self.assertEqual({team_id for team_id, _ in calls}, {11, 22})
+        self.assertTrue(all(force_refresh is False for _, force_refresh in calls))

--- a/tests/test_redeem_flow.py
+++ b/tests/test_redeem_flow.py
@@ -21,13 +21,21 @@ from app.utils.time_utils import get_now
 
 
 class StubRedemptionService:
+    def __init__(self, *, has_warranty=False, pool_type="normal", virtual_welfare_code=False, team_id=None):
+        self.has_warranty = has_warranty
+        self.pool_type = pool_type
+        self.virtual_welfare_code = virtual_welfare_code
+        self.team_id = team_id
+
     async def validate_code(self, code, db_session):
         return {
             "success": True,
             "valid": True,
             "redemption_code": {
-                "pool_type": "normal",
-                "virtual_welfare_code": False,
+                "pool_type": self.pool_type,
+                "virtual_welfare_code": self.virtual_welfare_code,
+                "has_warranty": self.has_warranty,
+                "team_id": self.team_id,
             },
         }
 
@@ -42,6 +50,10 @@ class StubTeamService:
         self.mapping_updates = []
         self.reserve_results = reserve_results or {}
         self.released_team_ids = []
+
+    @staticmethod
+    def _append_warranty_seat_condition(conditions, warranty_required):
+        return None
 
     @staticmethod
     def _normalize_member_email(email):
@@ -61,7 +73,7 @@ class StubTeamService:
         return {"success": True, "member_emails": [], "error": None}
 
 
-    async def reserve_seat_if_available(self, team_id, db_session, pool_type="normal"):
+    async def reserve_seat_if_available(self, team_id, db_session, pool_type="normal", warranty_required=None):
         queued = self.reserve_results.get(team_id) or []
         if queued:
             result = queued.pop(0)
@@ -79,6 +91,9 @@ class StubTeamService:
         team = await db_session.get(Team, team_id)
         if not team or team.pool_type != pool_type or team.status != "active":
             return {"success": False, "error": f"目标 Team {team_id} 不可用"}
+        if warranty_required is not None and team.warranty_seat_enabled != bool(warranty_required):
+            mode_label = "已开启质保的 Team" if warranty_required else "未开启质保的 Team"
+            return {"success": False, "error": f"当前兑换码仅可加入{mode_label}"}
         if team.current_members >= team.max_members:
             team.status = "full"
             return {"success": False, "error": "该 Team 已满, 请选择其他 Team 尝试"}
@@ -1847,6 +1862,112 @@ class TeamServiceBulkInviteTests(unittest.IsolatedAsyncioTestCase):
             async with self.session_factory() as session2:
                 team = await session2.get(Team, 101)
                 self.assertNotEqual(team.status, "error")
+                self.assertEqual(team.current_members, 2)
+                mapping_result = await session2.execute(
+                    select(TeamEmailMapping.status).where(
+                        TeamEmailMapping.team_id == 101,
+                        TeamEmailMapping.email == "newuser@example.com",
+                    )
+                )
+                self.assertEqual(mapping_result.scalar_one(), "invited")
+
+    async def test_add_team_member_does_not_double_count_existing_active_mapping(self):
+        await self._seed_team(current_members=2, max_members=5)
+        team_service = TeamService()
+
+        async def stub_sync(team_id, db_session, force_refresh=False):
+            return {
+                "success": True,
+                "message": "ok",
+                "member_emails": ["existing@example.com"],
+                "error": None,
+            }
+
+        async def stub_ensure_token(*args, **kwargs):
+            return "access-token"
+
+        async def stub_send_invite(*args, **kwargs):
+            return {
+                "success": True,
+                "data": {"account_invites": [{"email_address": "pending@example.com"}]},
+                "error": None,
+            }
+
+        async def stub_reset(*args, **kwargs):
+            return None
+
+        async def stub_bg_verify(*args, **kwargs):
+            return None
+
+        async with self.session_factory() as session:
+            await team_service.upsert_team_email_mapping(
+                team_id=101,
+                email="pending@example.com",
+                status="invited",
+                db_session=session,
+                source="admin_add",
+                is_admin_invited=True,
+            )
+            await session.commit()
+
+            with patch.object(team_service, "sync_team_info", new=stub_sync), \
+                 patch.object(team_service, "ensure_access_token", new=stub_ensure_token), \
+                 patch.object(team_service.chatgpt_service, "send_invite", new=stub_send_invite), \
+                 patch.object(team_service, "_reset_error_status", new=stub_reset), \
+                 patch.object(team_service, "_background_verify_admin_invite", new=stub_bg_verify):
+                result = await team_service.add_team_member(
+                    101, "pending@example.com", session
+                )
+
+        self.assertTrue(result["success"])
+        async with self.session_factory() as session2:
+            team = await session2.get(Team, 101)
+            self.assertEqual(team.current_members, 2)
+            self.assertEqual(team.status, "active")
+
+    async def test_add_team_member_marks_full_when_last_seat_is_invited(self):
+        await self._seed_team(current_members=5, max_members=6)
+        team_service = TeamService()
+
+        async def stub_sync(team_id, db_session, force_refresh=False):
+            return {
+                "success": True,
+                "message": "ok",
+                "member_emails": ["existing@example.com"],
+                "error": None,
+            }
+
+        async def stub_ensure_token(*args, **kwargs):
+            return "access-token"
+
+        async def stub_send_invite(*args, **kwargs):
+            return {
+                "success": True,
+                "data": {"account_invites": [{"email_address": "last-seat@example.com"}]},
+                "error": None,
+            }
+
+        async def stub_reset(*args, **kwargs):
+            return None
+
+        async def stub_bg_verify(*args, **kwargs):
+            return None
+
+        async with self.session_factory() as session:
+            with patch.object(team_service, "sync_team_info", new=stub_sync), \
+                 patch.object(team_service, "ensure_access_token", new=stub_ensure_token), \
+                 patch.object(team_service.chatgpt_service, "send_invite", new=stub_send_invite), \
+                 patch.object(team_service, "_reset_error_status", new=stub_reset), \
+                 patch.object(team_service, "_background_verify_admin_invite", new=stub_bg_verify):
+                result = await team_service.add_team_member(
+                    101, "last-seat@example.com", session
+                )
+
+        self.assertTrue(result["success"])
+        async with self.session_factory() as session2:
+            team = await session2.get(Team, 101)
+            self.assertEqual(team.current_members, 6)
+            self.assertEqual(team.status, "full")
 
     async def test_background_verify_admin_invite_does_not_flip_team_to_error(self):
         """后台校验失败时不应再把 Team 标记为 error。
@@ -1981,6 +2102,50 @@ class RedeemFlowServiceTests(unittest.IsolatedAsyncioTestCase):
             session.add_all([team_1, team_2, code])
             await session.commit()
 
+    async def _seed_warranty_routing_data(self):
+        async with self.session_factory() as session:
+            warranty_team = Team(
+                id=11,
+                email="warranty-owner@example.com",
+                access_token_encrypted="token-11",
+                account_id="acct-11",
+                team_name="Warranty Team",
+                current_members=1,
+                max_members=6,
+                status="active",
+                pool_type="normal",
+                warranty_seat_enabled=True,
+            )
+            normal_team = Team(
+                id=12,
+                email="normal-owner@example.com",
+                access_token_encrypted="token-12",
+                account_id="acct-12",
+                team_name="Normal Team",
+                current_members=1,
+                max_members=6,
+                status="active",
+                pool_type="normal",
+                warranty_seat_enabled=False,
+            )
+            warranty_code = RedemptionCode(
+                code="WARRANTY-CODE-0001",
+                status="unused",
+                pool_type="normal",
+                has_warranty=True,
+                warranty_days=30,
+                reusable_by_seat=False,
+            )
+            normal_code = RedemptionCode(
+                code="NORMAL-CODE-0001",
+                status="unused",
+                pool_type="normal",
+                has_warranty=False,
+                reusable_by_seat=False,
+            )
+            session.add_all([warranty_team, normal_team, warranty_code, normal_code])
+            await session.commit()
+
     @staticmethod
     def _close_coro(coro):
         coro.close()
@@ -2069,6 +2234,104 @@ class RedeemFlowServiceTests(unittest.IsolatedAsyncioTestCase):
             records = (await session.execute(select(RedemptionRecord))).scalars().all()
             self.assertEqual(len(records), 1)
             self.assertEqual(records[0].team_id, 2)
+
+    async def test_get_all_teams_includes_warranty_seat_flag(self):
+        await self._seed_warranty_routing_data()
+        team_service = TeamService()
+
+        async with self.session_factory() as session:
+            result = await team_service.get_all_teams(session, per_page=20, pool_type="normal")
+
+        self.assertTrue(result["success"])
+        team_flags = {team["id"]: team["warranty_seat_enabled"] for team in result["teams"]}
+        self.assertTrue(team_flags[11])
+        self.assertFalse(team_flags[12])
+
+    async def test_set_warranty_seat_enabled_updates_team_flag(self):
+        await self._seed_warranty_routing_data()
+        team_service = TeamService()
+
+        async with self.session_factory() as session:
+            result = await team_service.set_warranty_seat_enabled(12, True, session)
+            self.assertTrue(result["success"])
+            refreshed_team = await session.get(Team, 12)
+            self.assertTrue(refreshed_team.warranty_seat_enabled)
+
+    async def test_verify_code_only_returns_warranty_teams_for_warranty_code(self):
+        await self._seed_warranty_routing_data()
+        service = RedeemFlowService()
+
+        async with self.session_factory() as session:
+            result = await service.verify_code_and_get_teams("WARRANTY-CODE-0001", session)
+
+        self.assertTrue(result["success"])
+        self.assertTrue(result["valid"])
+        self.assertEqual([team["id"] for team in result["teams"]], [11])
+
+    async def test_verify_code_only_returns_non_warranty_teams_for_normal_code(self):
+        await self._seed_warranty_routing_data()
+        service = RedeemFlowService()
+
+        async with self.session_factory() as session:
+            result = await service.verify_code_and_get_teams("NORMAL-CODE-0001", session)
+
+        self.assertTrue(result["success"])
+        self.assertTrue(result["valid"])
+        self.assertEqual([team["id"] for team in result["teams"]], [12])
+
+    async def test_auto_select_routes_warranty_code_to_warranty_team(self):
+        await self._seed_warranty_routing_data()
+        service = RedeemFlowService()
+        service.chatgpt_service = StubChatGPTService(
+            {"acct-11": [{"success": True, "data": {"account_invites": [{"email": "warranty-user@example.com"}]}}]}
+        )
+
+        async with self.session_factory() as session:
+            with patch.object(service.team_service, "ensure_access_token", new=self._return_token), \
+                 patch("app.services.redeem_flow.asyncio.create_task", side_effect=self._close_coro):
+                result = await service.redeem_and_join_team(
+                    email="warranty-user@example.com",
+                    code="WARRANTY-CODE-0001",
+                    team_id=None,
+                    db_session=session,
+                )
+
+            self.assertTrue(result["success"])
+            self.assertEqual(result["team_info"]["id"], 11)
+
+            code = (await session.execute(
+                select(RedemptionCode).where(RedemptionCode.code == "WARRANTY-CODE-0001")
+            )).scalar_one()
+            self.assertEqual(code.used_team_id, 11)
+
+    async def test_manual_team_selection_rejects_mismatched_warranty_mode_without_consuming_code(self):
+        await self._seed_warranty_routing_data()
+        service = RedeemFlowService()
+        service.chatgpt_service = StubChatGPTService({})
+
+        async with self.session_factory() as session:
+            with patch.object(service.team_service, "ensure_access_token", new=self._return_token):
+                result = await service.redeem_and_join_team(
+                    email="wrong-target@example.com",
+                    code="WARRANTY-CODE-0001",
+                    team_id=12,
+                    db_session=session,
+                )
+
+            self.assertFalse(result["success"])
+            self.assertIn("仅可加入已开启质保的 Team", result["error"])
+
+            code = (await session.execute(
+                select(RedemptionCode).where(RedemptionCode.code == "WARRANTY-CODE-0001")
+            )).scalar_one()
+            self.assertEqual(code.status, "unused")
+            self.assertIsNone(code.used_team_id)
+
+            team = await session.get(Team, 12)
+            self.assertEqual(team.current_members, 1)
+
+            records = (await session.execute(select(RedemptionRecord))).scalars().all()
+            self.assertEqual(records, [])
 
     async def test_sync_reconcile_requires_three_misses_before_removed(self):
         await self._seed_basic_data()


### PR DESCRIPTION
Add a Team-level warranty seat toggle so warranty and non-warranty redemption codes route to separate Teams without affecting existing members. Also align batch refresh with single refresh behavior so health checks stop forcing token refreshes when a valid access token already exists.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lolollipop/team-manage-refresh/pull/205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
