### PR TITLE
fix: 修复 AT 直接导入表单提交

### DIFF
--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -754,6 +754,15 @@ function setSingleImportMode(mode = 'quick') {
     const isManual = mode === 'manual';
     quickSection.style.display = isManual ? 'none' : 'block';
     manualSection.style.display = isManual ? 'block' : 'none';
+
+    // display:none 不会让带 required 的控件退出 HTML 表单校验。
+    // 切换模式时禁用非当前模式的输入，避免隐藏的 AT 字段阻止提交。
+    [quickSection, manualSection].forEach((section) => {
+        const inactive = section !== (isManual ? manualSection : quickSection);
+        section.querySelectorAll('input, textarea, select').forEach((field) => {
+            field.disabled = inactive;
+        });
+    });
 }
 
 function syncResponsiveSidebarMount() {
@@ -1240,7 +1249,11 @@ async function handleSingleImport(event) {
     const clientId = form.clientId ? form.clientId.value.trim() : null;
     const email = form.email.value.trim();
     const accountId = form.accountId.value.trim();
-    const submitButton = form.querySelector('button[type="submit"]');
+    const activeSection = document.getElementById('manualTokenSection')?.style.display !== 'none'
+        ? document.getElementById('manualTokenSection')
+        : document.getElementById('oauthQuickSection');
+    const submitButton = activeSection?.querySelector('button[type="submit"]')
+        || form.querySelector('button[type="submit"]');
 
     submitButton.disabled = true;
     submitButton.textContent = '导入中...';


### PR DESCRIPTION
## 修改内容

修复单个 Team 导入中直接填写 AT 时，隐藏的一键导入字段参与浏览器必填校验导致表单无法提交的问题。

同时让提交处理函数始终操作当前可见导入模式的提交按钮。

## 验证

- JavaScript 语法检查通过
- 85 项 Python 单元测试全部通过