### PR TITLE
feat: 兼容 CLIProxyAPI Token 导入格式

### DIFF
--- a/app/services/team.py
+++ b/app/services/team.py
@@ -1557,6 +1557,58 @@ class TeamService:
                 "error": f"批量导入过程中发生异常: {str(e)}"
             }
 
+    @staticmethod
+    def _normalize_team_import_item(item: Dict[str, Any]) -> Optional[Dict[str, Optional[str]]]:
+        """归一化 CLIProxyAPI 认证文件及历史 Team JSON 格式。"""
+        if not isinstance(item, dict):
+            return None
+
+        # CLIProxyAPI 当前写出的 Codex 文件是扁平对象；其读取器同时兼容
+        # {"token": {"access_token": ...}}，部分工具还会再包一层 metadata。
+        sources: List[Dict[str, Any]] = []
+        pending = [item]
+        seen = set()
+        while pending:
+            source = pending.pop(0)
+            marker = id(source)
+            if marker in seen or not isinstance(source, dict):
+                continue
+            seen.add(marker)
+            sources.append(source)
+            for key in ("metadata", "token"):
+                nested = source.get(key)
+                if isinstance(nested, dict):
+                    pending.append(nested)
+
+        def first_value(*keys: str) -> Optional[str]:
+            for source in sources:
+                for key in keys:
+                    value = source.get(key)
+                    if value is not None and not isinstance(value, (dict, list)):
+                        normalized = str(value).strip()
+                        if normalized:
+                            return normalized
+            return None
+
+        access_token = first_value("access_token")
+        if not access_token:
+            token_value = item.get("token")
+            if isinstance(token_value, str) and token_value.strip():
+                access_token = token_value.strip()
+
+        normalized = {
+            "access_token": access_token,
+            "id_token": first_value("id_token"),
+            "refresh_token": first_value("refresh_token"),
+            "session_token": first_value("session_token"),
+            "client_id": first_value("client_id"),
+            "email": first_value("email"),
+            "account_id": first_value("account_id", "chatgpt_account_id"),
+        }
+        if not any((normalized["access_token"], normalized["refresh_token"], normalized["session_token"])):
+            return None
+        return normalized
+
     async def import_team_json(
         self,
         json_text: Optional[str],
@@ -1589,25 +1641,9 @@ class TeamService:
 
             normalized_items = []
             for item in raw_items:
-                if not isinstance(item, dict):
-                    continue
-
-                access_token = item.get("access_token") or item.get("token")
-                refresh_token = item.get("refresh_token")
-                session_token = item.get("session_token")
-
-                if not any([access_token, refresh_token, session_token]):
-                    continue
-
-                normalized_items.append({
-                    "access_token": access_token,
-                    "id_token": item.get("id_token"),
-                    "refresh_token": refresh_token,
-                    "session_token": session_token,
-                    "client_id": item.get("client_id"),
-                    "email": item.get("email"),
-                    "account_id": item.get("account_id")
-                })
+                normalized = self._normalize_team_import_item(item)
+                if normalized:
+                    normalized_items.append(normalized)
 
             if not normalized_items:
                 yield {"type": "error", "error": "JSON 中未找到可导入的 Team 项（需包含 AT/RT/ST）"}

--- a/tests/test_token_import.py
+++ b/tests/test_token_import.py
@@ -1,0 +1,65 @@
+import unittest
+
+from app.services.team import TeamService
+
+
+class TeamImportNormalizationTests(unittest.TestCase):
+    def test_cli_proxy_api_flat_auth_file(self):
+        item = {
+            "type": "codex",
+            "access_token": " at-flat ",
+            "refresh_token": "rt-flat",
+            "id_token": "id-flat",
+            "account_id": "account-flat",
+            "email": "flat@example.com",
+            "expired": "2026-08-12T12:00:00+08:00",
+        }
+
+        self.assertEqual(
+            TeamService._normalize_team_import_item(item),
+            {
+                "access_token": "at-flat",
+                "id_token": "id-flat",
+                "refresh_token": "rt-flat",
+                "session_token": None,
+                "client_id": None,
+                "email": "flat@example.com",
+                "account_id": "account-flat",
+            },
+        )
+
+    def test_nested_token_object_and_metadata_are_supported(self):
+        item = {
+            "type": "codex",
+            "metadata": {
+                "email": "nested@example.com",
+                "token": {
+                    "access_token": "at-nested",
+                    "refresh_token": "rt-nested",
+                    "id_token": "id-nested",
+                    "chatgpt_account_id": "account-nested",
+                },
+            },
+        }
+
+        normalized = TeamService._normalize_team_import_item(item)
+        self.assertEqual(normalized["access_token"], "at-nested")
+        self.assertEqual(normalized["refresh_token"], "rt-nested")
+        self.assertEqual(normalized["id_token"], "id-nested")
+        self.assertEqual(normalized["email"], "nested@example.com")
+        self.assertEqual(normalized["account_id"], "account-nested")
+
+    def test_legacy_string_token_is_treated_as_access_token(self):
+        normalized = TeamService._normalize_team_import_item(
+            {"token": "at-legacy", "email": "legacy@example.com"}
+        )
+
+        self.assertEqual(normalized["access_token"], "at-legacy")
+        self.assertEqual(normalized["email"], "legacy@example.com")
+
+    def test_unrelated_json_object_is_ignored(self):
+        self.assertIsNone(TeamService._normalize_team_import_item({"type": "codex"}))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

CLIProxyAPI 当前 Codex 认证文件支持扁平字段，并兼容嵌套 token/metadata 结构。现有 Team JSON 导入仅支持旧的顶层字段格式。

## 修改内容

- 兼容 CLIProxyAPI 扁平认证文件字段：`access_token`、`refresh_token`、`id_token`、`account_id`、`email`。
- 兼容嵌套的 `token` 对象、`metadata` 包装和历史字符串 `token` 格式。
- 支持 `chatgpt_account_id` 作为 Account ID 兼容别名。
- 新增 4 项 Token 导入归一化测试。

## 验证结果

- Python 单元测试：89 项全部通过。
- JavaScript 语法检查通过。
- `git diff --check` 通过。

参考项目：<https://github.com/router-for-me/CLIProxyAPI>