### PR TITLE
fix: harden database startup and health checks

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -67,7 +67,9 @@ async def init_db():
     创建所有表
     """
     async with engine.begin() as conn:
-        await conn.execute(text("PRAGMA journal_mode=WAL"))
+        # WAL 是 SQLite 专用设置；PostgreSQL/MySQL 等后端执行该语句会导致启动失败。
+        if _is_sqlite:
+            await conn.execute(text("PRAGMA journal_mode=WAL"))
         await conn.run_sync(Base.metadata.create_all)
 
 

--- a/app/db_migrations.py
+++ b/app/db_migrations.py
@@ -5,15 +5,21 @@
 import logging
 import sqlite3
 from pathlib import Path
-from datetime import datetime
 
 logger = logging.getLogger(__name__)
 
 
-def get_db_path():
-    """获取数据库文件路径"""
+def get_db_path() -> Path | None:
+    """返回文件型 SQLite 数据库路径；其他后端没有可迁移的本地数据库文件。"""
     from app.config import settings
-    db_file = settings.database_url.split("///")[-1]
+
+    database_url = settings.database_url
+    if not database_url.startswith("sqlite"):
+        return None
+
+    db_file = database_url.split(":///", 1)[-1]
+    if not db_file or db_file == ":memory:":
+        return None
     return Path(db_file)
 
 
@@ -39,7 +45,10 @@ def run_auto_migration():
     检测缺失的列并自动添加
     """
     db_path = get_db_path()
-    
+    if db_path is None:
+        logger.info("当前数据库不是文件型 SQLite，跳过 SQLite 自动迁移")
+        return
+
     if not db_path.exists():
         logger.info("数据库文件不存在，跳过迁移")
         return

--- a/app/main.py
+++ b/app/main.py
@@ -17,13 +17,15 @@ import logging
 from datetime import datetime
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
+from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
 
 from contextlib import asynccontextmanager
 # 导入路由
 from app import __version__
 from app.routes import redeem, auth, admin, api, user, warranty
 from app.config import settings
-from app.database import init_db, close_db, AsyncSessionLocal
+from app.database import init_db, close_db, AsyncSessionLocal, engine
 from app.services.auth import auth_service
 from app.services.team import team_service
 from app.utils.time_utils import get_now
@@ -437,9 +439,12 @@ async def lifespan(app: FastAPI):
             logger.info("质保过期自动踢人任务已禁用")
 
         logger.info("数据库初始化完成")
-    except Exception as e:
-        logger.error(f"数据库初始化失败: {e}")
-    
+    except Exception as exc:
+        # 数据库、迁移或任务初始化失败时不能继续对外提供服务，否则会导致
+        # /health 误报成功并在首次真实请求时才暴露故障。
+        logger.exception("数据库初始化失败，应用将停止启动")
+        raise RuntimeError("数据库初始化失败，应用未启动") from exc
+
     yield
     
     # 关闭定时任务
@@ -586,7 +591,14 @@ async def login_page(request: Request):
 
 @app.get("/health")
 async def health_check():
-    """健康检查端点"""
+    """检查应用是否仍可访问数据库。"""
+    try:
+        async with engine.connect() as connection:
+            await connection.execute(text("SELECT 1"))
+    except SQLAlchemyError:
+        logger.exception("健康检查失败：无法连接数据库")
+        return JSONResponse(status_code=503, content={"status": "unhealthy"})
+
     return {"status": "healthy"}
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+pythonpath = ["."]
+testpaths = ["tests"]

--- a/tests/test_startup_health.py
+++ b/tests/test_startup_health.py
@@ -1,0 +1,90 @@
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from fastapi.responses import JSONResponse
+from sqlalchemy.exc import SQLAlchemyError
+
+from app import database
+from app import main
+from app import db_migrations
+
+
+class _AsyncContext:
+    def __init__(self, value=None, error=None):
+        self.value = value
+        self.error = error
+
+    async def __aenter__(self):
+        if self.error is not None:
+            raise self.error
+        return self.value
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeConnection:
+    def __init__(self):
+        self.execute = AsyncMock()
+        self.run_sync = AsyncMock()
+
+
+class _FakeEngine:
+    def __init__(self, connection=None, error=None):
+        self.connection = connection
+        self.error = error
+
+    def begin(self):
+        return _AsyncContext(self.connection, self.error)
+
+    def connect(self):
+        return _AsyncContext(self.connection, self.error)
+
+
+class DatabaseCompatibilityTests(unittest.IsolatedAsyncioTestCase):
+    async def test_init_db_does_not_run_sqlite_pragma_for_non_sqlite_database(self):
+        connection = _FakeConnection()
+        engine = _FakeEngine(connection=connection)
+
+        with patch("app.database._is_sqlite", False), patch("app.database.engine", engine):
+            await database.init_db()
+
+        connection.execute.assert_not_awaited()
+        connection.run_sync.assert_awaited_once()
+
+
+class MigrationCompatibilityTests(unittest.TestCase):
+    def test_get_db_path_returns_none_for_non_sqlite_database(self):
+        with patch(
+            "app.config.settings.database_url",
+            "postgresql+asyncpg://user:password@db.example.com/app",
+        ):
+            self.assertIsNone(db_migrations.get_db_path())
+
+    def test_get_db_path_returns_none_for_in_memory_sqlite_database(self):
+        with patch(
+            "app.config.settings.database_url",
+            "sqlite+aiosqlite:///:memory:",
+        ):
+            self.assertIsNone(db_migrations.get_db_path())
+
+
+class StartupAndHealthTests(unittest.IsolatedAsyncioTestCase):
+    async def test_lifespan_fails_fast_when_database_initialization_fails(self):
+        with patch(
+            "app.main.init_db",
+            new=AsyncMock(side_effect=RuntimeError("database unavailable")),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "数据库初始化失败"):
+                async with main.lifespan(main.app):
+                    pass
+
+    async def test_health_check_returns_503_when_database_cannot_be_reached(self):
+        engine = _FakeEngine(error=SQLAlchemyError("database unavailable"))
+
+        with patch("app.main.engine", engine, create=True):
+            response = await main.health_check()
+
+        self.assertIsInstance(response, JSONResponse)
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.body, b'{"status":"unhealthy"}')


### PR DESCRIPTION
## Summary
- limit SQLite-specific WAL and migrations to file-backed SQLite databases
- fail application startup when database initialization fails
- make the health endpoint verify database connectivity
- add regression coverage and stable pytest path configuration

## Verification
- pytest -q (94 passed)
- ruff check app/main.py app/database.py app/db_migrations.py tests/test_startup_health.py --select E9,F401,F821,F823
- pip-audit -r requirements.txt